### PR TITLE
fix: hack for devmode crash at rollback

### DIFF
--- a/contract/test/game.test.js
+++ b/contract/test/game.test.js
@@ -152,12 +152,6 @@ describe( 'GameContract', () => {
                     "not_player1"
                 )
             } )
-            it( 'fails because no_hash', async () => {
-                await failsWith(
-                    () => contract.methods.player1_move( "rock", withP1() ),
-                    "no_hash"
-                )
-            } )
             describe( "after player1_move", () => {
                 //let player0 to add hash
                 beforeEach( async () => {
@@ -214,6 +208,14 @@ describe( 'GameContract', () => {
                     )
                 } )
             } )
+            describe('separate test because of dev-mode crash',()=>{
+                it( 'fails because no_hash', async () => {
+                    await failsWith(
+                        () => contract.methods.player1_move( "rock", withP1() ),
+                        "no_hash"
+                    )
+                } )
+            })
         } )
         describe( "reveal", () => {
             it( 'fails because not player0', async () => {


### PR DESCRIPTION
Fixes #51 

reordering below tests rollback isn't crashing anymore
    ✔ fails because not player1
    ✔ fails because no_hash
