### PR TITLE
fix: fix server hangup and error message showing when retrying

### DIFF
--- a/client/src/components/ChannelInitialization.vue
+++ b/client/src/components/ChannelInitialization.vue
@@ -11,6 +11,8 @@ const emit = defineEmits(['initializeChannel']);
 const title = computed(() =>
   !openChannelInitiated.value
     ? 'Start the game by open state channel'
+    : !channelStore.channel?.isFunded
+    ? 'Funding accounts...'
     : !channelStore.channel?.isOpen
     ? 'Setting ‘on-chain’ operations...'
     : 'Waiting for contract to be deployed...'

--- a/client/src/sdk/GameChannel.ts
+++ b/client/src/sdk/GameChannel.ts
@@ -74,16 +74,16 @@ export class GameChannel {
       stake: new BigNumber(data.gameStake),
     };
     if (res.status != 200) {
-      this.error = {
-        status: res.status,
-        statusText: res.statusText,
-        message: data.error || 'Error while fetching channel config',
-      };
-      if (this?.error?.message?.includes('greylisted')) {
+      if (data.error.includes('greylisted')) {
         console.log('Greylisted account, retrying with new account');
         this.sdk = await getSdk();
         return this.fetchChannelConfig();
-      }
+      } else
+        this.error = {
+          status: res.status,
+          statusText: res.statusText,
+          message: data.error || 'Error while fetching channel config',
+        };
       throw new Error(data.error);
     }
     return data as ChannelOptions;

--- a/client/src/sdk/GameChannel.ts
+++ b/client/src/sdk/GameChannel.ts
@@ -22,6 +22,7 @@ export class GameChannel {
   channelConfig?: ChannelOptions;
   channelInstance?: Channel;
   isOpen = false;
+  isFunded = false;
   error?: {
     status: number;
     statusText: string;
@@ -93,6 +94,7 @@ export class GameChannel {
     await this.fetchChannelConfig()
       .then(async (config) => {
         this.channelConfig = config;
+        this.isFunded = true;
         await this.openChannel();
       })
       .catch((e) => console.error(e));

--- a/client/tests/channel-initialization.test.ts
+++ b/client/tests/channel-initialization.test.ts
@@ -18,7 +18,7 @@ describe('Open State Channel Button', () => {
       channelComp.getByText('Start game');
     }).toThrowError();
 
-    channelComp.getByText('Setting ‘on-chain’ operations...');
+    channelComp.getByText('Funding accounts...');
   });
 
   it('shows error message on error', async () => {

--- a/client/tests/sdk.test.ts
+++ b/client/tests/sdk.test.ts
@@ -177,6 +177,6 @@ describe('GameChannel', () => {
       const gameChannel = new GameChannel(sdk);
       await gameChannel.fetchChannelConfig();
       expect(fetchSpy).toHaveBeenCalledTimes(2);
-    }, 6000);
+    }, 10000);
   });
 });

--- a/server/src/services/bot/bot.service.spec.ts
+++ b/server/src/services/bot/bot.service.spec.ts
@@ -118,7 +118,7 @@ describe('botService', () => {
       expect(axiosSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should retry by default 1 time when error code is different than 425', async () => {
+    it('should retry by default 200 time when error code is different than 425', async () => {
       mockedAxios.post.mockRejectedValue(
         new AxiosError('Unavailable', '500', null, null, {
           status: 500,
@@ -130,7 +130,7 @@ describe('botService', () => {
         }),
       );
       await expect(botService.fundThroughFaucet(accountMock)).rejects.toThrow();
-      expect(axiosSpy).toHaveBeenCalledTimes(2);
+      expect(axiosSpy).toHaveBeenCalledTimes(201);
     });
 
     it('should retry 3 times with a total delay of 4.5 seconds when given maxRetries:2 and retryDelay:500', async () => {
@@ -145,20 +145,12 @@ describe('botService', () => {
         }),
       );
 
-      const startTime = performance.now();
-
       await expect(
         botService.fundThroughFaucet(accountMock, {
           maxRetries: 3,
-          retryDelay: 500,
         }),
       ).rejects.toThrow();
       expect(axiosSpy).toHaveBeenCalledTimes(4);
-      const endTime = performance.now();
-
-      const totalDelay = endTime - startTime;
-      expect(totalDelay).toBeGreaterThanOrEqual(4500);
-      expect(totalDelay).toBeLessThanOrEqual(6500);
     });
 
     it('should not throw an error if account has enough coins', async () => {

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -8,7 +8,6 @@ import { ChannelOptions } from '@aeternity/aepp-sdk/es/channel/internal';
 import { EncodedData } from '@aeternity/aepp-sdk/es/utils/encoder';
 import BigNumber from 'bignumber.js';
 import axios, { AxiosError } from 'axios';
-import { setTimeout } from 'timers/promises';
 import { deployContract, genesisFund } from '../sdk/sdk.service';
 import {
   IS_USING_LOCAL_NODE,
@@ -64,14 +63,11 @@ export async function fundThroughFaucet(
   account: EncodedData<'ak'>,
   options: {
     maxRetries?: number;
-    retryDelay?: number;
   } = {
-    maxRetries: 1,
-    retryDelay: 1000,
+    maxRetries: 200,
   },
 ): Promise<void> {
   const FAUCET_URL = 'https://faucet.aepps.com';
-  if (Number.isNaN(options.retryDelay)) options.retryDelay = 1000;
   try {
     await axios.post(`${FAUCET_URL}/account/${account}`, {});
     return logger.info(`Funded account ${account} through Faucet`);
@@ -84,10 +80,8 @@ export async function fundThroughFaucet(
       logger.warn(
         `Faucet is currently unavailable. Retrying at maximum ${options.maxRetries} more times`,
       );
-      await setTimeout(options.retryDelay);
       return fundThroughFaucet(account, {
         maxRetries: options.maxRetries - 1,
-        retryDelay: options.retryDelay + 1000,
       });
     }
     logger.error({ error }, 'failed to fund account through faucet');

--- a/server/test/integration/bot.service.spec.ts
+++ b/server/test/integration/bot.service.spec.ts
@@ -68,6 +68,7 @@ describe('botService', () => {
       sign: (_tag: string, tx: EncodedData<'tx'>) => playerSdk.signTransaction(tx),
     });
     await waitForChannelReady(playerChannel);
+    await timeout(5000);
     await playerChannel.shutdown(playerSdk.signTransaction.bind(playerSdk));
     await timeout(1000);
 


### PR DESCRIPTION
Found out that if the server retries faucet funding with a delay, it basically hangs every other action (event loop :eyes:). Therefore this pr removes the delay, increases tries. Also, updates client to never show the user that an account is greylisted but keep it as a part of the connection setup