### PR TITLE
fix(ci): use the correct backend url on stg env

### DIFF
--- a/.github/workflows/stg-frontend.yml
+++ b/.github/workflows/stg-frontend.yml
@@ -74,7 +74,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VITE_NODE_ENV=staging
-            VITE_BOT_SERVICE_URL=https://state-channel-demo-backend.dev.aepps.com
+            VITE_BOT_SERVICE_URL=https://pr-${{ env.PR_NUMBER }}-state-channel-demo-backend.stg.aepps.com
             VITE_CLIENT_PORT=8000 
             VITE_NODE_URL=https://testnet.aeternity.io
             VITE_COMPILER_URL= https://compiler.aepps.com


### PR DESCRIPTION
This pull request fixes env variables for the staging client environment regarding the server url

How to confirm:

1. navigate to https://pr-76-state-channel-demo-frontend.stg.aepps.com/
2. open dev tools -> network tab
3. initiate channel
4. make sure that the request is at https://pr-76-state-channel-demo-backend.stg.aepps.com/