### PR TITLE
Feat: Persist state

### DIFF
--- a/client/src/app.vue
+++ b/client/src/app.vue
@@ -25,14 +25,16 @@ const showTerminal = computed(
 
 const showingAutoplayTxLogs = computed(
   () =>
-    channelStore.channel?.game.autoplay.enabled &&
+    channelStore.channel?.autoplay.enabled &&
     channelStore.channel?.contractAddress &&
     !channelStore.channel?.shouldShowEndScreen
 );
 
 onMounted(async () => {
   await initSdk();
-  channelStore.channel = new GameChannel();
+  const channel = new GameChannel();
+  channelStore.channel = channel;
+  await channelStore.channel.restoreGameState();
 });
 </script>
 
@@ -46,9 +48,7 @@ onMounted(async () => {
       "
       @initializeChannel="initChannel()"
     />
-    <RockPaperScissors
-      v-else-if="!channelStore.channel.game.autoplay.enabled"
-    />
+    <RockPaperScissors v-else-if="!channelStore.channel.autoplay.enabled" />
     <TransactionsList v-if="showTerminal" />
   </div>
 </template>

--- a/client/src/components/channel-initialization/channel-initialization.test.ts
+++ b/client/src/components/channel-initialization/channel-initialization.test.ts
@@ -21,6 +21,38 @@ describe('Open State Channel Button', () => {
     channelComp.getByText('Funding accounts...');
   });
 
+  it('should have `Reconnecting` title when there is a stored gameState', async () => {
+    localStorage.setItem('gameState', '{}');
+    const channelComp = render(ChannelInitialization, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            initialState: {
+              channel: {
+                channel: {
+                  isOpen: true,
+                  isFunded: true,
+                },
+              },
+            },
+          }),
+        ],
+      },
+    });
+    const button = channelComp.getByText('Start game');
+    await fireEvent.click(button);
+    // button is hidden after clicking it
+    expect(() => {
+      channelComp.getByText('Start game');
+    }).toThrowError();
+
+    expect(
+      channelComp.getByText(
+        'Reconnecting - Waiting for contract to be compiled...'
+      )
+    ).toBeDefined();
+  });
+
   it('shows error message on error', async () => {
     const channelComp = render(ChannelInitialization, {
       global: {

--- a/client/src/components/channel-initialization/channel-initialization.vue
+++ b/client/src/components/channel-initialization/channel-initialization.vue
@@ -3,21 +3,33 @@ import { computed, ref } from 'vue';
 import { default as Button } from '../generic-button/generic-button.vue';
 import LoadingAnimation from '../loading-animation/loading-animation.vue';
 import { useChannelStore } from '../../stores/channel';
-import ToggleButton from '../toggle-button/toggle-button.vue';
 
-const openChannelInitiated = ref(false);
 const channelStore = useChannelStore();
-const emit = defineEmits(['initializeChannel']);
+const openChannelInitiated = ref(false);
+const channelisOpening = computed(
+  () => channelStore.channel?.isOpening || openChannelInitiated.value
+);
 
-const title = computed(() =>
-  !openChannelInitiated.value
+const emit = defineEmits(['initializeChannel']);
+const hasSavedState = !!localStorage.getItem('gameState');
+
+const title = computed(() => {
+  const prefix = hasSavedState ? 'Reconnecting - ' : '';
+
+  const contractRequiredAction = hasSavedState
+    ? 'compiled'
+    : 'deployed & compiled';
+
+  const status = !channelisOpening.value
     ? 'Start the game by open state channel'
     : !channelStore.channel?.isFunded
     ? 'Funding accounts...'
     : !channelStore.channel?.isOpen
     ? 'Setting ‘on-chain’ operations...'
-    : 'Waiting for contract to be deployed...'
-);
+    : ` Waiting for contract to be ${contractRequiredAction}...`;
+
+  return prefix + status;
+});
 
 const errorMessage = computed(() =>
   channelStore.channel?.error
@@ -29,57 +41,40 @@ async function openStateChannel(): Promise<void> {
   openChannelInitiated.value = true;
   emit('initializeChannel');
 }
-
-function toggleAutoplay() {
-  if (channelStore.channel) {
-    channelStore.channel.game.autoplay.enabled =
-      !channelStore.channel.game.autoplay.enabled;
-  }
-}
 </script>
 
 <template>
   <div class="open-channel">
-    <div class="container" :class="{ shadow: !openChannelInitiated }">
-      <div
-        class="title"
-        :style="{
-          'max-width': openChannelInitiated ? '100%' : '',
-        }"
-      >
-        {{ title }}
-      </div>
-      <div class="info-wrapper" v-if="!openChannelInitiated">
-        <p class="info">
-          State channels refer to the process in which users transact with one
-          another directly outside of the blockchain, or ‘off-chain,’ and
-          greatly minimize their use of ‘on-chain’ operations.
-        </p>
-        <p class="info">
-          By clicking start game you are initiating state channel with our bot
-          and you make the possibilities of the game practically endless. After
-          the game is over, you can see every action recorded on the blockchain
-          by checking our explorer.
-        </p>
-        <div>
-          <Button
-            :disabled="openChannelInitiated"
-            @click="openStateChannel()"
-            text="Start game"
-          />
-          <ToggleButton
-            id="autoplay"
-            v-on:change="toggleAutoplay"
-            label-enable-text="Autoplay"
-            label-disable-text="Autoplay"
-          />
-        </div>
-      </div>
-      <LoadingAnimation v-else-if="!channelStore.channel?.error" />
-      <p v-else>
-        {{ errorMessage }}
-      </p>
+    <div
+      class="title"
+      :style="{
+        'max-width': channelisOpening ? '100%' : '',
+      }"
+    >
+      {{ title }}
     </div>
+    <div class="info-wrapper" v-if="!channelisOpening">
+      <p class="info">
+        State channels refer to the process in which users transact with one
+        another directly outside of the blockchain, or ‘off-chain,’ and greatly
+        minimize their use of ‘on-chain’ operations.
+      </p>
+      <p class="info">
+        By clicking start game you are initiating state channel with our bot and
+        you make the possibilities of the game practically endless. After the
+        game is over, you can see every action recorded on the blockchain by
+        checking our explorer.
+      </p>
+      <Button
+        :disabled="channelisOpening"
+        @click="openStateChannel()"
+        text="Start game"
+      />
+    </div>
+    <LoadingAnimation v-else-if="!channelStore.channel?.error" />
+    <p v-else>
+      {{ errorMessage }}
+    </p>
   </div>
 </template>
 

--- a/client/src/components/end-screen/end-screen.test.ts
+++ b/client/src/components/end-screen/end-screen.test.ts
@@ -13,8 +13,8 @@ import {
 describe('Show end screen', async () => {
   expect(EndScreen).toBeTruthy();
   const gameChannel = new GameChannel();
-  gameChannel.game.autoplay.enabled = true;
-  gameChannel.game.autoplay.elapsedTime = 1000;
+  gameChannel.autoplay.enabled = true;
+  gameChannel.autoplay.elapsedTime = 1000;
   gameChannel.balances.user = new BigNumber(10e18);
   gameChannel.channelConfig = {
     responderAmount: new BigNumber(5e18),

--- a/client/src/components/end-screen/end-screen.vue
+++ b/client/src/components/end-screen/end-screen.vue
@@ -15,7 +15,7 @@ const repoURL = 'https://github.com/aeternity/state-channel-demo';
 const transactions = useTransactionsStore()
   .userTransactions.flat()
   .filter((tx) => tx.onChain === false);
-const seconds = channel.game.autoplay.elapsedTime / 1000;
+const seconds = channel.autoplay.elapsedTime / 1000;
 const title = computed(() =>
   earnings.value.isZero()
     ? "You didn't win or lose anything"
@@ -27,12 +27,12 @@ const txPerSecText = computed(
   () =>
     `${transactions.length} off-chain transaction${
       transactions.length > 1 ? 's' : ''
-    } ${channel.game.autoplay.enabled ? `in ${seconds}sec` : ''}`
+    } ${channel.autoplay.enabled ? `in ${seconds}sec` : ''}`
 );
 const roundsPlayed = computed(
   () =>
-    `${channel.game.round.index} round${
-      channel.game.round.index > 1 ? 's' : ''
+    `${channel.gameRound.index} round${
+      channel.gameRound.index > 1 ? 's' : ''
     } played`
 );
 const earnings = computed(() => {
@@ -71,7 +71,7 @@ function continueAutoplay() {
       <Button :url="repoURL" text="Fork a repo" />
       <Button text="Check Explorer" disabled />
       <Button
-        v-if="channel.game.autoplay.enabled"
+        v-if="channel.autoplay.enabled"
         text="Continue Autoplay"
         :disabled="channel.channelIsClosing || hasInsuffientBalance"
         @click="continueAutoplay()"
@@ -82,7 +82,7 @@ function continueAutoplay() {
         "
       />
       <Button
-        v-if="channel.game.autoplay.enabled"
+        v-if="channel.autoplay.enabled"
         text="Close Channel"
         :disabled="channel.channelIsClosing"
         @click="closeChannel()"

--- a/client/src/components/header/header.vue
+++ b/client/src/components/header/header.vue
@@ -19,8 +19,8 @@ async function reset() {
     <PlayerInfo name="You" :balance="channelStore.channel?.balances.user" />
     <div class="center">
       <GameInfo
-        :stake="channelStore.channel?.game?.stake"
-        :round="channelStore.channel?.game?.round.index"
+        :stake="channelStore.channel?.gameRound?.stake"
+        :round="channelStore.channel?.gameRound?.index"
         v-if="channelStore.channel?.isOpen"
       />
     </div>

--- a/client/src/components/rock-paper-scissors/rock-paper-scissor.test.ts
+++ b/client/src/components/rock-paper-scissors/rock-paper-scissor.test.ts
@@ -1,8 +1,9 @@
-import { GameChannel, Selections } from '../../utils/game-channel/game-channel';
+import { GameChannel } from '../../utils/game-channel/game-channel';
 import { render, fireEvent } from '@testing-library/vue';
 import { describe, it, expect, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import RockPaperScissors from './rock-paper-scissors.vue';
+import { Selections } from '../../utils/game-channel/game-channel.types';
 
 describe('Rock Paper Scissors Component', () => {
   const gameChannel = new GameChannel();
@@ -71,7 +72,7 @@ describe('Rock Paper Scissors Component', () => {
   it('displays only user selection if game is not completed', async () => {
     await gameChannel.setUserSelection(Selections.rock);
     gameChannel.setBotSelection(Selections.paper);
-    gameChannel.game.round.isCompleted = true;
+    gameChannel.gameRound.isCompleted = true;
 
     const RockPaperScissorsEl = render(RockPaperScissors, {
       global: {
@@ -99,8 +100,8 @@ describe('Rock Paper Scissors Component', () => {
   it('resets game state if user wants to play another round', async () => {
     await gameChannel.setUserSelection(Selections.paper);
     gameChannel.setBotSelection(Selections.paper);
-    gameChannel.game.round.isCompleted = true;
-    gameChannel.game.round.winner = 'ak_test';
+    gameChannel.gameRound.isCompleted = true;
+    gameChannel.gameRound.winner = 'ak_test';
 
     const RockPaperScissorsEl = render(RockPaperScissors, {
       global: {

--- a/client/src/components/rock-paper-scissors/rock-paper-scissors.vue
+++ b/client/src/components/rock-paper-scissors/rock-paper-scissors.vue
@@ -16,7 +16,7 @@ const userHasSelected = computed(() => {
     : false;
 });
 
-const showSelectionButtons = computed(() => {
+const isSelectingDisabled = computed(() => {
   return userHasSelected.value || selectionClicked.value;
 });
 
@@ -41,7 +41,7 @@ const botSelection = computed(() =>
 );
 
 const status = computed(() => {
-  if (!showSelectionButtons.value) {
+  if (!isSelectingDisabled.value) {
     return 'Choose one';
   }
   if (botIsMakingSelection.value) {
@@ -72,6 +72,7 @@ async function makeSelection(selection: Selections) {
 }
 
 function closeChannel() {
+  localStorage.clear();
   channelIsClosing.value = true;
   gameChannel.channel?.closeChannel();
 }
@@ -98,10 +99,10 @@ function closeChannel() {
         />
       </div>
     </div>
-    <div v-if="showSelectionButtons" class="selections">
+    <div v-if="!isSelectingDisabled" class="selections">
       <button
         data-testid="rock-btn"
-        :disabled="showSelectionButtons"
+        :disabled="isSelectingDisabled"
         class="button"
         @click="makeSelection(Selections.rock)"
       >
@@ -109,7 +110,7 @@ function closeChannel() {
       </button>
       <button
         data-testid="paper-btn"
-        :disabled="showSelectionButtons"
+        :disabled="isSelectingDisabled"
         class="button"
         @click="makeSelection(Selections.paper)"
       >
@@ -117,7 +118,7 @@ function closeChannel() {
       </button>
       <button
         data-testid="scissors-btn"
-        :disabled="showSelectionButtons"
+        :disabled="isSelectingDisabled"
         class="button"
         @click="makeSelection(Selections.scissors)"
       >

--- a/client/src/components/rock-paper-scissors/rock-paper-scissors.vue
+++ b/client/src/components/rock-paper-scissors/rock-paper-scissors.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { Selections } from '../../utils/game-channel/game-channel';
+import { Selections } from '../../utils/game-channel/game-channel.types';
 import { useChannelStore } from '../../stores/channel';
 import GenericButton from '../generic-button/generic-button.vue';
 import SelectionIcon from '../selection-icon/selection-icon.vue';
@@ -35,10 +35,8 @@ const userSelection = computed(() =>
 );
 
 const botSelection = computed(() =>
-  gameChannel.channel?.game.round.botSelection != Selections.none
-    ? Selections[
-        gameChannel.channel?.game.round.botSelection ?? Selections.none
-      ]
+  gameChannel.channel?.gameRound.botSelection != Selections.none
+    ? Selections[gameChannel.channel?.gameRound.botSelection ?? Selections.none]
     : ''
 );
 
@@ -49,8 +47,8 @@ const status = computed(() => {
   if (botIsMakingSelection.value) {
     return 'Bot is selecting';
   }
-  if (gameChannel.channel?.game.round.isCompleted) {
-    switch (gameChannel.channel?.game.round.winner) {
+  if (gameChannel.channel?.gameRound.isCompleted) {
+    switch (gameChannel.channel?.gameRound.winner) {
       case gameChannel.channel.channelConfig?.responderId:
         return 'You won';
       case gameChannel.channel.channelConfig?.initiatorId:
@@ -90,7 +88,7 @@ function closeChannel() {
       </div>
       <h1 class="title">{{ status }}</h1>
       <div
-        v-if="gameChannel.channel?.game.round.isCompleted"
+        v-if="gameChannel.channel?.gameRound.isCompleted"
         class="finalized-selection bot"
         data-testid="botSelection"
       >
@@ -100,7 +98,7 @@ function closeChannel() {
         />
       </div>
     </div>
-    <div v-if="!showSelectionButtons" class="selections">
+    <div v-if="showSelectionButtons" class="selections">
       <button
         data-testid="rock-btn"
         :disabled="showSelectionButtons"
@@ -127,7 +125,7 @@ function closeChannel() {
       </button>
     </div>
     <div
-      v-if="gameChannel.channel?.game.round.isCompleted"
+      v-if="gameChannel.channel?.gameRound.isCompleted"
       class="round-controls"
     >
       <GenericButton

--- a/client/src/components/selection-icon/selection-icon.vue
+++ b/client/src/components/selection-icon/selection-icon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Selections } from '../../utils/game-channel/game-channel';
+import { Selections } from '../../utils/game-channel/game-channel.types';
 
 const props = defineProps<{
   type: Selections;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './app.vue';
 
-export let app = createApp(App);
+let app = createApp(App);
 let pinia = createPinia();
 app.use(pinia);
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -2,12 +2,14 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './app.vue';
 
-let app = createApp(App);
+export let app = createApp(App);
 let pinia = createPinia();
 app.use(pinia);
-app.mount('#app');
+
+if (process.env.NODE_ENV !== 'test') app.mount('#app');
 
 export function resetApp() {
+  localStorage.removeItem('gameState');
   app.unmount();
   app = createApp(App);
   pinia = createPinia();

--- a/client/src/stores/transactions.ts
+++ b/client/src/stores/transactions.ts
@@ -21,5 +21,11 @@ export const useTransactionsStore = defineStore('transactions', {
       this.botTransactions[round] ??= [];
       this.botTransactions[round].push(transaction);
     },
+    setUserTransactions(transactions: TransactionLog[][]) {
+      this.userTransactions = transactions;
+    },
+    setBotTransactions(transactions: TransactionLog[][]) {
+      this.botTransactions = transactions;
+    },
   },
 });

--- a/client/src/utils/game-channel/game-channel.test.ts
+++ b/client/src/utils/game-channel/game-channel.test.ts
@@ -1,9 +1,11 @@
+import { BigNumber } from 'bignumber.js';
 import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
-import { GameChannel, Selections } from './game-channel';
+import { GameChannel } from './game-channel';
 import { initSdk, sdk } from '../sdk-service/sdk-service';
 import contractSource from '@aeternity/rock-paper-scissors';
+import { Selections } from './game-channel.types';
 
 describe('GameChannel', async () => {
   const gameChannel = new GameChannel();
@@ -33,7 +35,7 @@ describe('GameChannel', async () => {
   it('creates game channel instance', async () => {
     expect(gameChannel).toBeTruthy();
     expect(gameChannel.getUserSelection()).toBe(Selections.none);
-    expect(gameChannel.game.round.botSelection).toBe(Selections.none);
+    expect(gameChannel.gameRound.botSelection).toBe(Selections.none);
   });
 
   it('can set/get selection for user', async () => {
@@ -98,8 +100,8 @@ describe('GameChannel', async () => {
 
       gameChannel.finishGameRound(winner);
 
-      expect(gameChannel.game.round.winner).toBe(winner);
-      expect(gameChannel.game.round.isCompleted).toBe(true);
+      expect(gameChannel.gameRound.winner).toBe(winner);
+      expect(gameChannel.gameRound.isCompleted).toBe(true);
       expect(updateBalancesSpy).toHaveBeenCalled();
     });
   });
@@ -107,7 +109,8 @@ describe('GameChannel', async () => {
   describe('startNewRound()', () => {
     it('increments round index and resets state', () => {
       const gameChannel = new GameChannel();
-      gameChannel.game.round = {
+      gameChannel.gameRound = {
+        stake: new BigNumber(10),
         index: 3,
         isCompleted: true,
         winner: 'ak_me',
@@ -117,7 +120,8 @@ describe('GameChannel', async () => {
       };
       gameChannel.startNewRound();
 
-      expect(gameChannel.game.round).toEqual({
+      expect(gameChannel.gameRound).toEqual({
+        stake: new BigNumber(10),
         index: 4,
         isCompleted: false,
         winner: undefined,
@@ -129,7 +133,7 @@ describe('GameChannel', async () => {
       gameChannel.startNewRound();
       gameChannel.startNewRound();
 
-      expect(gameChannel.game.round.index).toBe(6);
+      expect(gameChannel.gameRound.index).toBe(6);
     });
   });
 });

--- a/client/src/utils/game-channel/game-channel.test.ts
+++ b/client/src/utils/game-channel/game-channel.test.ts
@@ -6,6 +6,10 @@ import { GameChannel } from './game-channel';
 import { initSdk, sdk } from '../sdk-service/sdk-service';
 import contractSource from '@aeternity/rock-paper-scissors';
 import { Selections } from './game-channel.types';
+import { Channel } from '@aeternity/aepp-sdk';
+import { ChannelOptions } from '@aeternity/aepp-sdk/es/channel/internal';
+import * as main from '../../main';
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 
 describe('GameChannel', async () => {
   const gameChannel = new GameChannel();
@@ -20,6 +24,11 @@ describe('GameChannel', async () => {
     source: contractSource,
     compile: () => ({ bytecode: 'bytecode_mock' }),
   } as unknown as ContractInstance);
+
+  const getChannelWithoutProxySpy = vi.spyOn(
+    gameChannel,
+    'getChannelWithoutProxy'
+  );
 
   beforeEach(async () => {
     createTestingPinia({
@@ -114,6 +123,7 @@ describe('GameChannel', async () => {
         index: 3,
         isCompleted: true,
         winner: 'ak_me',
+        userInAction: false,
         userSelection: Selections.paper,
         botSelection: Selections.rock,
         hasRevealed: true,
@@ -127,6 +137,7 @@ describe('GameChannel', async () => {
         winner: undefined,
         userSelection: Selections.none,
         botSelection: Selections.none,
+        userInAction: false,
         hasRevealed: false,
       });
 
@@ -134,6 +145,151 @@ describe('GameChannel', async () => {
       gameChannel.startNewRound();
 
       expect(gameChannel.gameRound.index).toBe(6);
+    });
+  });
+
+  describe('checkIfChannelIsEstablished()', async () => {
+    getChannelWithoutProxySpy
+      .mockReturnValueOnce({
+        state: function () {
+          return new Promise((resolve) => {
+            setTimeout(resolve, 5000);
+          });
+        },
+      } as Channel)
+      .mockReturnValueOnce({
+        state: function () {
+          return new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+        },
+      } as Channel);
+
+    it('returns false when state() promise takes more than 3000ms', async () => {
+      expect(await gameChannel.checkIfChannelIsEstablished()).toBe(false);
+    });
+    it('returns true when state() promise takes less than 3000ms', async () => {
+      expect(await gameChannel.checkIfChannelIsEstablished()).toBe(true);
+    });
+  });
+
+  describe('reconnectChannel()', async () => {
+    const gameChannel = new GameChannel();
+    const getChannelWithoutProxySpy = vi.spyOn(
+      gameChannel,
+      'getChannelWithoutProxy'
+    );
+    const reconnectSpy = vi.spyOn(Channel, 'reconnect');
+    const checkIfChannelIsEstablishedSpy = vi.spyOn(
+      gameChannel,
+      'checkIfChannelIsEstablished'
+    );
+    const alertSpy = vi.spyOn(window, 'alert');
+    const resetAppSpy = vi.spyOn(main, 'resetApp').mockResolvedValue();
+    const registerEventsSpy = vi.spyOn(gameChannel, 'registerEvents');
+
+    reconnectSpy.mockResolvedValue({} as Channel);
+    checkIfChannelIsEstablishedSpy
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    it('alerts user that the channel was shutdown and resets app', async () => {
+      gameChannel.channelConfig = {} as ChannelOptions;
+      localStorage.setItem('gameState', 'test');
+      await gameChannel.reconnectChannel();
+      expect(alertSpy).toHaveBeenCalled();
+      expect(localStorage.getItem('gameState')).toBe(null);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 3000);
+      });
+      expect(resetAppSpy).toHaveBeenCalled();
+    });
+
+    it('re-registers events on channel reconnect', async () => {
+      getChannelWithoutProxySpy.mockReturnValue({
+        on: () => ({}),
+      } as unknown as Channel);
+      gameChannel.channelConfig = {} as ChannelOptions;
+      localStorage.setItem('gameState', 'test');
+      await gameChannel.reconnectChannel();
+      expect(gameChannel.isOpen).toBe(true);
+      expect(gameChannel.isFunded).toBe(true);
+      expect(registerEventsSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('saveStateToLocalStorage()', async () => {
+    it('saves state to localStorage', async () => {
+      const gameChannel = new GameChannel();
+      const gameRound = {
+        stake: new BigNumber(10),
+        index: 3,
+        isCompleted: true,
+        winner: 'ak_me' as Encoded.AccountAddress,
+        userSelection: Selections.paper,
+        botSelection: Selections.rock,
+        userInAction: false,
+        hasRevealed: true,
+      };
+      gameChannel.gameRound = gameRound;
+      gameChannel.contractCreationChannelRound = 3;
+      gameChannel.channelConfig = {} as ChannelOptions;
+      gameChannel.saveStateToLocalStorage();
+
+      const { stake, ...restgameRound } = gameRound;
+      const { stake: savedStake, ...savedRound } = JSON.parse(
+        localStorage.getItem('gameState') || '{}'
+      ).gameRound;
+      expect(stake.toString()).toEqual(savedStake.toString());
+      expect(savedRound).toEqual(restgameRound);
+    });
+  });
+
+  describe('restoreGameState()', async () => {
+    const gameChannel = new GameChannel();
+    const reconnectChannelSpy = vi
+      .spyOn(gameChannel, 'reconnectChannel')
+      .mockResolvedValue({} as NodeJS.Timeout);
+    const buildContractSpy = vi
+      .spyOn(gameChannel, 'buildContract')
+      .mockResolvedValue();
+    const updateBalancesSpy = vi
+      .spyOn(gameChannel, 'updateBalances')
+      .mockResolvedValue();
+
+    it('returns when there is no stored state', async () => {
+      localStorage.clear();
+      await gameChannel.restoreGameState();
+      expect(gameChannel.gameRound).toEqual({
+        stake: new BigNumber(0),
+        index: 1,
+        userInAction: false,
+        userSelection: Selections.none,
+        botSelection: Selections.none,
+        isCompleted: false,
+      });
+    });
+
+    it('restores game state', async () => {
+      gameChannel.gameRound = {
+        stake: new BigNumber(10),
+        userInAction: false,
+        index: 3,
+        isCompleted: true,
+        winner: 'ak_me' as Encoded.AccountAddress,
+        userSelection: Selections.paper,
+        botSelection: Selections.rock,
+        hasRevealed: true,
+      };
+      gameChannel.contractCreationChannelRound = 3;
+      gameChannel.fsmId = 'fsmId';
+      gameChannel.channelId = 'ch_ala';
+      gameChannel.channelConfig = {} as ChannelOptions;
+      gameChannel.saveStateToLocalStorage();
+      await gameChannel.restoreGameState();
+      expect(reconnectChannelSpy).toHaveBeenCalled();
+      expect(buildContractSpy).toHaveBeenCalled();
+      expect(updateBalancesSpy).toHaveBeenCalled();
     });
   });
 });

--- a/client/src/utils/game-channel/game-channel.ts
+++ b/client/src/utils/game-channel/game-channel.ts
@@ -1,4 +1,9 @@
-import { Channel, encodeContractAddress, unpackTx } from '@aeternity/aepp-sdk';
+import {
+  Channel,
+  encodeContractAddress,
+  MemoryAccount,
+  unpackTx,
+} from '@aeternity/aepp-sdk';
 import contractSource from '@aeternity/rock-paper-scissors';
 import { ChannelOptions } from '@aeternity/aepp-sdk/es/channel/internal';
 import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
@@ -7,6 +12,7 @@ import { nextTick, toRaw } from 'vue';
 import {
   decodeCallData,
   initSdk,
+  keypair,
   returnCoinsToFaucet,
   sdk,
   verifyContractBytecode,
@@ -15,38 +21,22 @@ import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
 import SHA from 'sha.js';
 import { useTransactionsStore } from '../../stores/transactions';
 import { TransactionLog } from '../../components/transaction/transaction.vue';
-
-interface Update {
-  call_data: Encoded.ContractBytearray;
-  contract_id: Encoded.ContractAddress;
-  op: 'OffChainCallContract' | 'OffChainNewContract';
-  code?: Encoded.ContractBytearray;
-  owner?: Encoded.AccountAddress;
-  caller_id?: Encoded.AccountAddress;
-}
-
-enum Methods {
-  init = 'init',
-  provide_hash = 'provide_hash',
-  get_state = 'get_state',
-  player1_move = 'player1_move',
-  reveal = 'reveal',
-  player1_dispute_no_reveal = 'player1_dispute_no_reveal',
-  player0_dispute_no_move = 'player0_dispute_no_move',
-  set_timestamp = 'set_timestamp',
-}
-
-export enum Selections {
-  rock = 'rock',
-  paper = 'paper',
-  scissors = 'scissors',
-  none = 'none',
-}
+import { resetApp } from '../../main';
+import { GameRound, Methods, Selections, Update } from './game-channel.types';
+import {
+  getSavedState,
+  StoredState,
+  storeGameState,
+} from '../local-storage/local-storage';
 
 export class GameChannel {
   channelConfig?: ChannelOptions;
   channelInstance?: Channel;
+  channelRound: number | null = null;
+  channelId?: string;
+  fsmId?: string;
   isOpen = false;
+  isOpening = false;
   isFunded = false;
   shouldShowEndScreen = false;
   timerStartTime = -1;
@@ -64,39 +54,27 @@ export class GameChannel {
     user: undefined,
     bot: undefined,
   };
-  game: {
-    autoplay: {
-      enabled: boolean;
-      rounds: number;
-      extraRounds: number; // extra rounds to play when continuing autoplay
-      elapsedTime: number; // time elapsed while autoplay is playing
-    };
-    stake?: BigNumber;
-    round: {
-      index: number;
-      hashKey?: string;
-      userSelection?: Selections;
-      botSelection?: Selections;
-      winner?: Encoded.AccountAddress;
-      isCompleted?: boolean;
-      hasRevealed?: boolean;
-    };
+  autoplay: {
+    enabled: boolean;
+    rounds: number;
+    extraRounds: number; // extra rounds to play when continuing autoplay
+    elapsedTime: number; // time elapsed while autoplay is playing
   } = {
-    autoplay: {
-      enabled: false,
-      rounds: 10,
-      extraRounds: 10,
-      elapsedTime: 0,
-    },
-    round: {
-      index: 1,
-      userSelection: Selections.none,
-      botSelection: Selections.none,
-      isCompleted: false,
-    },
+    enabled: false,
+    rounds: 10,
+    extraRounds: 10,
+    elapsedTime: 0,
+  };
+  gameRound: GameRound = {
+    stake: new BigNumber(0),
+    index: 1,
+    userSelection: Selections.none,
+    botSelection: Selections.none,
+    isCompleted: false,
   };
   contract?: ContractInstance;
   contractAddress?: Encoded.ContractAddress;
+  contractCreationChannelRound?: number;
 
   // since gameChannel is reactive, we need to get the raw channel instance
   getChannelWithoutProxy() {
@@ -111,14 +89,14 @@ export class GameChannel {
   }
 
   getSelectionHash(selection: Selections): string {
-    this.game.round.hashKey = Math.random().toString(16).substring(2, 8);
+    this.gameRound.hashKey = Math.random().toString(16).substring(2, 8);
     return SHA('sha256')
-      .update(this.game.round.hashKey + selection)
+      .update(this.gameRound.hashKey + selection)
       .digest('hex');
   }
 
   getUserSelection() {
-    return this.game.round.userSelection;
+    return this.gameRound.userSelection;
   }
 
   async setUserSelection(selection: Selections) {
@@ -129,7 +107,7 @@ export class GameChannel {
     const result = await this.callContract(Methods.provide_hash, [
       this.getSelectionHash(selection),
     ]);
-    if (result?.accepted) this.game.round.userSelection = selection;
+    if (result?.accepted) this.gameRound.userSelection = selection;
     else {
       console.error(result);
       throw new Error('Selection was not accepted');
@@ -137,7 +115,7 @@ export class GameChannel {
   }
 
   setBotSelection(selection: Selections) {
-    this.game.round.botSelection = selection;
+    this.gameRound.botSelection = selection;
   }
 
   async fetchChannelConfig(): Promise<ChannelOptions> {
@@ -154,7 +132,7 @@ export class GameChannel {
       }),
     });
     const data = await res.json();
-    this.game.stake = new BigNumber(data.gameStake);
+    this.gameRound.stake = new BigNumber(data.gameStake);
     if (res.status != 200) {
       if (data.error.includes('greylisted')) {
         console.log('Greylisted account, retrying with new account');
@@ -171,11 +149,11 @@ export class GameChannel {
     return data as ChannelOptions;
   }
 
-  async initializeChannel() {
-    const config = await this.fetchChannelConfig();
+  async initializeChannel(config?: ChannelOptions) {
+    this.isOpening = true;
+    if (!config) config = await this.fetchChannelConfig();
     this.channelConfig = config;
     this.isFunded = true;
-
     this.channelInstance = await Channel.initialize({
       ...this.channelConfig,
       role: 'responder',
@@ -186,7 +164,61 @@ export class GameChannel {
           ? import.meta.env.VITE_WS_URL
           : this.channelConfig.url,
     });
-    this.timerStartTime = Date.now();
+    this.registerEvents();
+  }
+
+  /**
+   * returns true if channel was never shutdown
+   * and reconnection was successful.
+   * In cases where channel was shutdown, `channel.state()`
+   * hangs for a while, therefore we add a timeout
+   */
+  async checkIfChannelIsEstablished() {
+    function timeout(ms: number) {
+      return new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('timeout succeeded')), ms);
+      });
+    }
+    const statePromise = this.getChannelWithoutProxy().state();
+
+    try {
+      await Promise.race([statePromise, timeout(3000)]);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async reconnectChannel() {
+    if (!this.channelConfig) throw new Error('Channel config is not set');
+    this.isOpening = true;
+    this.channelInstance = await Channel.reconnect(
+      {
+        ...this.channelConfig,
+        role: 'responder',
+        // @ts-expect-error ts-mismatch
+        sign: this.signTx.bind(this),
+      },
+      {
+        channelId: this.channelConfig.existingChannelId,
+        role: 'responder',
+        pubkey: this.channelConfig?.responderId,
+        round: this.channelRound,
+      }
+    );
+
+    const reconnectionWasSuccessful = await this.checkIfChannelIsEstablished();
+    if (!reconnectionWasSuccessful) {
+      alert(
+        'Channel was shutdown and can no longer be opened. App will reset.'
+      );
+      localStorage.removeItem('gameState');
+      return setTimeout(resetApp, 2000);
+    }
+
+    this.isFunded = true;
+    this.isOpen = true;
+
     this.registerEvents();
   }
 
@@ -244,7 +276,10 @@ export class GameChannel {
       if (!update.owner) throw new Error('Owner is not set');
       if (!isContractValid) throw new Error('Contract is not valid');
 
-      void this.buildContract(tx, update.owner);
+      // @ts-expect-error ts-mismatch
+      void this.buildContract(unpackTx(tx).tx.round, update.owner).then(() =>
+        this.logContractDeployment(tx)
+      );
     }
 
     // for both user and bot calls to the contract
@@ -265,16 +300,23 @@ export class GameChannel {
       this.getChannelWithoutProxy().on('statusChanged', (status) => {
         if (status === 'open') {
           this.isOpen = true;
+          this.isOpening = false;
+
+          if (!this.channelId)
+            this.channelId = this.getChannelWithoutProxy().id();
+          if (!this.fsmId) this.fsmId = this.getChannelWithoutProxy().fsmId();
           this.updateBalances();
         }
       });
 
       this.getChannelWithoutProxy().on('stateChanged', () => {
+        this.channelRound = this.getChannelWithoutProxy().round();
+        if (this.isOpen) this.saveStateToLocalStorage();
         if (
-          this.game.round.botSelection != Selections.none &&
-          !this.game.round.hasRevealed
+          this.gameRound.botSelection != Selections.none &&
+          !this.gameRound.hasRevealed
         ) {
-          this.game.round.hasRevealed = true;
+          this.gameRound.hasRevealed = true;
           nextTick(() => this.revealRoundResult());
         }
       });
@@ -285,14 +327,22 @@ export class GameChannel {
     }
   }
 
-  async buildContract(tx: Encoded.Transaction, owner: Encoded.AccountAddress) {
-    // @ts-expect-error ts-mismatch
-    const contractCreationRound = unpackTx(tx).tx.round;
+  async buildContract(
+    contractCreationChannelRound: number,
+    owner: Encoded.AccountAddress
+  ) {
+    this.contractCreationChannelRound = contractCreationChannelRound;
     this.contract = await sdk.getContractInstance({
       source: contractSource,
     });
     await this.contract.compile();
-    this.contractAddress = encodeContractAddress(owner, contractCreationRound);
+    this.contractAddress = encodeContractAddress(
+      owner,
+      contractCreationChannelRound
+    );
+  }
+
+  logContractDeployment(tx: Encoded.Transaction) {
     const transactionLog: TransactionLog = {
       id: tx,
       description: 'Deploy contract',
@@ -303,7 +353,7 @@ export class GameChannel {
     useTransactionsStore().addUserTransaction(transactionLog, 0);
 
     // if autoplay is enabled, make user selection automatically
-    if (this.game.autoplay.enabled) {
+    if (this.autoplay.enabled) {
       this.setUserSelection(this.getRandomSelection());
     }
   }
@@ -321,7 +371,7 @@ export class GameChannel {
     }
     const result = await this.getChannelWithoutProxy().callContract(
       {
-        amount: amount ?? this.game.stake,
+        amount: amount ?? this.gameRound.stake,
         callData: this.contract.calldata.encode(
           'RockPaperScissors',
           method,
@@ -398,30 +448,39 @@ export class GameChannel {
     }
     useTransactionsStore().addUserTransaction(
       transactionLog,
-      this.game.round.index
+      this.gameRound.index
     );
+  }
+
+  async getRoundContractCall(caller: Encoded.AccountAddress, round: number) {
+    if (!this.channelConfig) throw new Error('No channel configuration');
+    if (!this.contract) throw new Error('Contract is not set');
+    if (!this.contractAddress) throw new Error('Contract address is not set');
+
+    return await this.getChannelWithoutProxy().getContractCall({
+      caller: caller,
+      contract: this.contractAddress,
+      round,
+    });
   }
 
   async revealRoundResult() {
     await this.callContract(
       Methods.reveal,
-      [this.game.round.hashKey, this.game.round.userSelection],
+      [this.gameRound.hashKey, this.gameRound.userSelection],
       0 // reveal method is not payable, so we use 0
     );
 
     const currentRound = this?.getChannelWithoutProxy().round();
 
     if (!this.channelConfig) throw new Error('No channel configuration');
-    if (!this.contractAddress) throw new Error('Contract address is not set');
     if (!currentRound) throw new Error('No current round');
     if (!this.contract) throw new Error('Contract is not set');
-    if (!this.channelInstance) throw new Error('Channel is not open');
 
-    const result = await this.getChannelWithoutProxy().getContractCall({
-      caller: this.channelConfig.responderId,
-      contract: this.contractAddress,
-      round: currentRound,
-    });
+    const result = await this.getRoundContractCall(
+      this.channelConfig.responderId,
+      currentRound
+    );
 
     const winner = this.contract.calldata.decode(
       'RockPaperScissors',
@@ -433,18 +492,18 @@ export class GameChannel {
   }
 
   async finishGameRound(winner?: Encoded.AccountAddress) {
-    this.game.round.winner = winner;
-    this.game.round.isCompleted = true;
+    this.gameRound.winner = winner;
+    this.gameRound.isCompleted = true;
+    this.saveStateToLocalStorage();
     await this.updateBalances();
 
     // if autoplay is enabled
-    if (this.game.autoplay.enabled) {
+    if (this.autoplay.enabled) {
       // if not last round, start next round
-      if (this.game.round.index < this.game.autoplay.rounds)
-        this.startNewRound();
+      if (this.gameRound.index < this.autoplay.rounds) this.startNewRound();
       // otherwise, show results
       else {
-        this.game.autoplay.elapsedTime +=
+        this.autoplay.elapsedTime +=
           this.lastOffChainTxTime - this.timerStartTime;
         this.shouldShowEndScreen = true;
       }
@@ -452,24 +511,21 @@ export class GameChannel {
   }
 
   startNewRound() {
-    this.game.round.index++;
-    this.game.round.userSelection = Selections.none;
-    this.game.round.botSelection = Selections.none;
-    this.game.round.isCompleted = false;
-    this.game.round.hasRevealed = false;
-    this.game.round.winner = undefined;
+    this.gameRound.index++;
+    this.gameRound.userSelection = Selections.none;
+    this.gameRound.botSelection = Selections.none;
+    this.gameRound.isCompleted = false;
+    this.gameRound.hasRevealed = false;
+    this.gameRound.winner = undefined;
 
     // if autoplay is enabled, make user selection automatically
-    if (
-      this.game.autoplay.enabled &&
-      this.game.round.index <= this.game.autoplay.rounds
-    ) {
+    if (this.autoplay.enabled && this.gameRound.index <= this.autoplay.rounds) {
       this.setUserSelection(this.getRandomSelection());
     }
   }
 
   continueAutoplay() {
-    this.game.autoplay.rounds += this.game.autoplay.extraRounds;
+    this.autoplay.rounds += this.autoplay.extraRounds;
     this.shouldShowEndScreen = false;
     this.timerStartTime = Date.now();
     this.startNewRound();
@@ -481,9 +537,57 @@ export class GameChannel {
       const round =
         txLog.onChain || txLog.description === 'Deploy contract'
           ? 0
-          : this.game.round.index;
+          : this.gameRound.index;
       useTransactionsStore().addBotTransaction(txLog, round);
     }
+  }
+
+  saveStateToLocalStorage() {
+    if (!this.channelConfig || !this.contractCreationChannelRound) return;
+    const stateToSave: StoredState = {
+      keypair: getSavedState()?.keypair || keypair,
+      channelId: this.channelId as Encoded.Channel,
+      fsmId: this.fsmId,
+      channelConfig: {
+        ...this.channelConfig,
+        existingChannelId: this.channelId,
+        existingFsmId: this.fsmId,
+      },
+      channelRound: this.channelRound,
+      gameRound: { ...this.gameRound },
+      transactionLogs: {
+        userTransactions: useTransactionsStore().userTransactions,
+        botTransactions: useTransactionsStore().botTransactions,
+      },
+      contractCreationChannelRound: this.contractCreationChannelRound,
+    };
+    storeGameState(stateToSave);
+  }
+
+  async restoreGameState() {
+    const savedState = getSavedState();
+    if (!savedState) return;
+    await sdk.addAccount(new MemoryAccount({ keypair: savedState.keypair }), {
+      select: true,
+    });
+    this.channelId = savedState.channelId;
+    this.channelRound = savedState.channelRound;
+    this.fsmId = savedState.fsmId;
+    this.gameRound = savedState.gameRound;
+    this.gameRound.stake = new BigNumber(savedState.gameRound.stake);
+    useTransactionsStore().setUserTransactions(
+      savedState.transactionLogs.userTransactions
+    );
+    useTransactionsStore().setBotTransactions(
+      savedState.transactionLogs.botTransactions
+    );
+    this.channelConfig = savedState.channelConfig;
+    await this.reconnectChannel();
+    await this.buildContract(
+      savedState.contractCreationChannelRound,
+      savedState.channelConfig?.initiatorId
+    );
+    await this.updateBalances();
   }
 
   private getRandomSelection(): Selections {

--- a/client/src/utils/game-channel/game-channel.types.ts
+++ b/client/src/utils/game-channel/game-channel.types.ts
@@ -10,6 +10,7 @@ export interface GameRound {
   winner?: Encoded.AccountAddress;
   isCompleted?: boolean;
   hasRevealed?: boolean;
+  userInAction: boolean;
 }
 
 export interface Update {

--- a/client/src/utils/game-channel/game-channel.types.ts
+++ b/client/src/utils/game-channel/game-channel.types.ts
@@ -1,0 +1,40 @@
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
+import { BigNumber } from 'bignumber.js';
+
+export interface GameRound {
+  stake: BigNumber;
+  index: number;
+  hashKey?: string;
+  userSelection?: Selections;
+  botSelection?: Selections;
+  winner?: Encoded.AccountAddress;
+  isCompleted?: boolean;
+  hasRevealed?: boolean;
+}
+
+export interface Update {
+  call_data: Encoded.ContractBytearray;
+  contract_id: Encoded.ContractAddress;
+  op: 'OffChainCallContract' | 'OffChainNewContract';
+  code?: Encoded.ContractBytearray;
+  owner?: Encoded.AccountAddress;
+  caller_id?: Encoded.AccountAddress;
+}
+
+export enum Methods {
+  init = 'init',
+  provide_hash = 'provide_hash',
+  get_state = 'get_state',
+  player1_move = 'player1_move',
+  reveal = 'reveal',
+  player1_dispute_no_reveal = 'player1_dispute_no_reveal',
+  player0_dispute_no_move = 'player0_dispute_no_move',
+  set_timestamp = 'set_timestamp',
+}
+
+export enum Selections {
+  rock = 'rock',
+  paper = 'paper',
+  scissors = 'scissors',
+  none = 'none',
+}

--- a/client/src/utils/local-storage/local-storage.ts
+++ b/client/src/utils/local-storage/local-storage.ts
@@ -1,0 +1,47 @@
+import { GameRound } from '../game-channel/game-channel.types';
+import { ChannelOptions } from '@aeternity/aepp-sdk/es/channel/internal';
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
+import { TransactionLog } from '../../components/transaction/transaction.vue';
+import { resetApp } from '../../main';
+
+export interface StoredState {
+  // In a real application, this should be more private
+  keypair: {
+    publicKey: Encoded.AccountAddress;
+    secretKey: string;
+  };
+  channelId?: Encoded.Channel;
+  fsmId?: string;
+  channelConfig: ChannelOptions;
+  channelRound: number | null;
+  gameRound: GameRound;
+  transactionLogs: {
+    userTransactions: TransactionLog[][];
+    botTransactions: TransactionLog[][];
+  };
+  contractCreationChannelRound: number;
+}
+
+export function getSavedState() {
+  try {
+    const state = JSON.parse(localStorage.getItem('gameState') || '{}');
+    if (Object.keys(state).length === 0) return null;
+    if (!state.keypair || state.contractCreationChannelRound == null) {
+      throw new Error('Corrupted localstorage.');
+    }
+    return state as StoredState;
+  } catch (e) {
+    localStorage.removeItem('gameState');
+    alert('Corrupted localStorage. App will reset.');
+
+    resetApp();
+  }
+}
+
+export function storeGameState(state: StoredState) {
+  try {
+    localStorage.setItem('gameState', JSON.stringify(state));
+  } catch (e) {
+    console.info('Error saving state to local storage', e);
+  }
+}

--- a/client/src/utils/local-storage/local-storage.ts
+++ b/client/src/utils/local-storage/local-storage.ts
@@ -13,7 +13,7 @@ export interface StoredState {
   channelId?: Encoded.Channel;
   fsmId?: string;
   channelConfig: ChannelOptions;
-  channelRound: number | null;
+  channelRound?: number;
   gameRound: GameRound;
   transactionLogs: {
     userTransactions: TransactionLog[][];
@@ -33,7 +33,6 @@ export function getSavedState() {
   } catch (e) {
     localStorage.removeItem('gameState');
     alert('Corrupted localStorage. App will reset.');
-
     resetApp();
   }
 }

--- a/client/src/utils/sdk-service/sdk-service.test.ts
+++ b/client/src/utils/sdk-service/sdk-service.test.ts
@@ -110,7 +110,7 @@ describe('SDK', () => {
       await expect(
         verifyContractBytecode(contract.bytecode, contractSource)
       ).resolves.toBeTruthy();
-    });
+    }, 10000);
 
     it('returns false if proposed bytecode is wrong', async () => {
       const contract = await sdk.getContractInstance({

--- a/client/src/utils/sdk-service/sdk-service.ts
+++ b/client/src/utils/sdk-service/sdk-service.ts
@@ -18,9 +18,10 @@ const FAUCET_PUBLIC_ADDRESS = import.meta.env
   .VITE_FAUCET_PUBLIC_ADDRESS as Encoded.AccountAddress;
 
 export let sdk: AeSdk;
+export const keypair = generateKeyPair();
 
 export async function getNewSdk() {
-  const account = new MemoryAccount({ keypair: generateKeyPair() });
+  const account = new MemoryAccount({ keypair });
   const node = new Node(NODE_URL);
   const newSdk = new AeSdk({
     nodes: [{ name: 'testnet', instance: node }],

--- a/server/src/services/bot/bot.interface.ts
+++ b/server/src/services/bot/bot.interface.ts
@@ -1,9 +1,19 @@
+import { BigNumber } from 'bignumber.js';
 import { Channel } from '@aeternity/aepp-sdk';
+import { ChannelState } from '@aeternity/aepp-sdk/es/channel/internal';
 import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
 import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 
 export interface GameSession {
-  channel: Channel;
+  channelWrapper: {
+    instance: Channel;
+    poi?: Encoded.Poi;
+    state?: ChannelState;
+    balances?: {
+      responderAmount: BigNumber;
+      initiatorAmount: BigNumber;
+    };
+  };
   contractState?: {
     instance?: ContractInstance;
     callDataToSend?: Encoded.ContractBytearray;

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -207,7 +207,7 @@ async function handleChannelDied(onAccount: Encoded.AccountAddress) {
       waitMined: true,
     });
   } catch (e) {
-    // Sometimes the notch is used, yet the channel does shutdown.
+    // Sometimes the nonce is used, yet the channel does shutdown.
     logger.info(
       `Channel with initiator ${onAccount} was shutdown with error:`,
       await (e as any).verifyTx(),

--- a/server/src/services/sdk/sdk.service.ts
+++ b/server/src/services/sdk/sdk.service.ts
@@ -6,21 +6,17 @@ import { setTimeout } from 'timers/promises';
 import {
   COMPILER_URL,
   FAUCET_ACCOUNT,
-  IGNORE_NODE_VERSION,
   IS_USING_LOCAL_NODE,
-  NETWORK_ID,
   NODE_URL,
 } from './sdk.constants';
 import logger from '../../logger';
 
 export const sdk = new AeSdk({
-  networkId: NETWORK_ID,
   compilerUrl: COMPILER_URL,
-  ignoreVersion: IGNORE_NODE_VERSION,
   nodes: [
     {
-      name: 'test',
-      instance: new Node(NODE_URL, { ignoreVersion: IGNORE_NODE_VERSION }),
+      name: 'testnet',
+      instance: new Node(NODE_URL),
     },
   ],
 });

--- a/server/test/integration/bot.service.spec.ts
+++ b/server/test/integration/bot.service.spec.ts
@@ -226,7 +226,7 @@ describe('botService', () => {
       expect(botBalance.eq(playerBalance));
     }
 
-    await playerChannel.leave();
+    await playerChannel.shutdown(playerSdk.signTransaction.bind(playerSdk));
     await timeout(1500);
   });
 });

--- a/server/test/mocks.ts
+++ b/server/test/mocks.ts
@@ -1,4 +1,5 @@
 import { Channel } from '@aeternity/aepp-sdk';
+import BigNumber from 'bignumber.js';
 import { randomUUID } from 'crypto';
 import { ChannelMock } from './interfaces';
 
@@ -11,6 +12,18 @@ export const mockChannel = () => {
       },
       id() {
         return `ch_${randomUUID()}`;
+      },
+      poi() {
+        return `pi_${randomUUID()}`;
+      },
+      balances() {
+        return {
+          responderAmount: new BigNumber(0),
+          initiatorAmount: new BigNumber(0),
+        };
+      },
+      state() {
+        return {};
       },
       createContract: jest.fn(),
     } as ChannelMock),


### PR DESCRIPTION
- Removed network id field as it is not required by default
- updated `gameRound` fields on client side - better handling
- updated `gameSession` fields on server side - better handling
- handled `died` channel state by triggering solo close on bot's side as described here: https://github.com/aeternity/protocol/blob/master/node/api/channels_api_usage.md#timeout-error

**A condition (see at the bottom) is failing due to some issues**
1. Fetching last contract call with channel.getContractCall() may result in a hanging promise. The node will kill the channel but no error will pop. 
2. No documented way of deserializing/decoding contract state

**The state reconnection is successful only when**
1. A new round has started and the user needs to make a pick
2. A round has finished and the user needs to choose between playing another or closing the channel
3. Player half signed the reveal method, triggered window reload, bot signed, player reconnected

**Not successful condition**
Reloading between user and bot pick