### PR TITLE
feat(server): add cors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docker-compose.override.yml
 node_modules/
 .env.production
 Makefile
+docker/data

--- a/client/src/utils/game-channel/game-channel.ts
+++ b/client/src/utils/game-channel/game-channel.ts
@@ -11,8 +11,8 @@ import { BigNumber } from 'bignumber.js';
 import { nextTick, toRaw } from 'vue';
 import {
   decodeCallData,
-  initSdk,
   keypair,
+  refreshSdkAccount,
   returnCoinsToFaucet,
   sdk,
   verifyContractBytecode,
@@ -146,7 +146,7 @@ export class GameChannel {
     if (res.status != 200) {
       if (data.error.includes('greylisted')) {
         console.log('Greylisted account, retrying with new account');
-        initSdk();
+        await refreshSdkAccount();
         return this.fetchChannelConfig();
       } else
         this.error = {
@@ -166,6 +166,7 @@ export class GameChannel {
     this.isFunded = true;
     this.channelInstance = await Channel.initialize({
       ...this.channelConfig,
+      debug: true,
       role: 'responder',
       // @ts-expect-error ts-mismatch
       sign: this.signTx.bind(this),

--- a/client/src/utils/sdk-service/sdk-service.ts
+++ b/client/src/utils/sdk-service/sdk-service.ts
@@ -20,6 +20,12 @@ const FAUCET_PUBLIC_ADDRESS = import.meta.env
 export let sdk: AeSdk;
 export const keypair = generateKeyPair();
 
+export async function refreshSdkAccount() {
+  if (sdk.selectedAddress) sdk.removeAccount(sdk.selectedAddress);
+  const account = new MemoryAccount({ keypair: generateKeyPair() });
+  await sdk.addAccount(account, { select: true });
+}
+
 export async function getNewSdk() {
   const account = new MemoryAccount({ keypair });
   const node = new Node(NODE_URL);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,6 +4,12 @@ import { route } from './route';
 
 export const app = express();
 
-app.use(cors());
+const corsOptions = process.env.NODE_ENV === 'development'
+  ? null
+  : {
+    origin: [/\.aeternity\.com\/?$/, /\.aepps\.com\/?$/],
+  };
+
+app.use(cors(corsOptions));
 app.use(express.json());
 app.use('/', route);


### PR DESCRIPTION
- closes #34 
- client: enable debug
- client: fix a bug where sdk didn't update keypair  
- updates `.gitignore` with persistent network data

Seems like gh actions can't deploy the server so the cors options cannot be tested properly :eye: 