### PR TITLE
revert(server): remove faucet retry

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ const start = (port: string | number) => {
       logger.info(`Bot service running at port ${port}`);
     });
   } catch (err) {
-    console.error(err);
+    logger.error(`Fatal error: ${err.toString()}`);
     process.exit();
   }
 };

--- a/server/src/services/bot/bot.constants.ts
+++ b/server/src/services/bot/bot.constants.ts
@@ -14,7 +14,11 @@ export const MUTUAL_CHANNEL_CONFIGURATION: Partial<ChannelOptions> & {
   initiatorAmount: new BigNumber('4.5e18'),
   responderAmount: new BigNumber('4.5e18'),
   channelReserve: 2,
-  lockPeriod: 10,
+  // We're using 0 for lockPeriod in order to quickly close the channel
+  // in cases where the initiator needs to solo close it and finally.
+  // execute channel_settle transaction
+  // read more: https://github.com/aeternity/protocol/blob/master/channels/ON-CHAIN.md#channel_settle
+  lockPeriod: 0,
   // workaround: minimize the number of node hangs
   timeoutIdle: 2 * 60 * 60 * 1000,
   debug: false,

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -151,6 +151,7 @@ function sendOpenStateChannelTxLog(
  * Returns funds to the faucet and removes the game session from the pool
  */
 export async function handleChannelClose(onAccount: Encoded.AccountAddress) {
+  removeGameSession(onAccount);
   try {
     await sdk.transferFunds(1, FAUCET_PUBLIC_ADDRESS, {
       onAccount,
@@ -159,7 +160,6 @@ export async function handleChannelClose(onAccount: Encoded.AccountAddress) {
   } catch (e) {
     logger.error({ e }, 'failed to return funds to faucet');
   }
-  removeGameSession(onAccount);
   sdk.removeAccount(onAccount);
 }
 
@@ -283,6 +283,13 @@ export async function registerEvents(
     if (status === 'died') {
       logger.info(`channel with initiator ${configuration.initiatorId} died.`);
       void handleChannelDied(configuration.initiatorId);
+    }
+
+    if (status === 'error') {
+      logger.error(
+        `channel with initiator ${configuration.initiatorId} threw error.`,
+      );
+      void removeGameSession(configuration.initiatorId);
     }
 
     if (status === 'open') {

--- a/server/src/services/sdk/sdk.service.spec.ts
+++ b/server/src/services/sdk/sdk.service.spec.ts
@@ -38,41 +38,6 @@ describe('fundThroughFaucet()', () => {
     expect(axiosSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should retry by default 200 time when error code is different than 425', async () => {
-    mockedAxios.post.mockRejectedValue(
-      new AxiosError('Unavailable', '500', null, null, {
-        status: 500,
-        statusText: 'Unavailable',
-        headers: {},
-        config: {},
-        request: {},
-        data: [],
-      }),
-    );
-    await expect(fundThroughFaucet(accountMock)).rejects.toThrow();
-    expect(axiosSpy).toHaveBeenCalledTimes(201);
-  });
-
-  it('should retry 3 times maxRetries:3', async () => {
-    mockedAxios.post.mockRejectedValue(
-      new AxiosError('Unavailable', '500', null, null, {
-        status: 500,
-        statusText: 'Unavailable',
-        headers: {},
-        config: {},
-        request: {},
-        data: [],
-      }),
-    );
-
-    await expect(
-      fundThroughFaucet(accountMock, {
-        maxRetries: 3,
-      }),
-    ).rejects.toThrow();
-    expect(axiosSpy).toHaveBeenCalledTimes(4);
-  });
-
   it('should not throw an error if account has enough coins', async () => {
     mockedAxios.post.mockRejectedValue(
       new AxiosError('Greylist', '425', null, null, {


### PR DESCRIPTION
This PR removes the faucet retry since the faucet web app will greylist the given account anyway. By removing it, we speedup the new initialization process.