### PR TITLE
Feature/link to users aenalytics page

### DIFF
--- a/client/src/components/game-screen/game-screen.vue
+++ b/client/src/components/game-screen/game-screen.vue
@@ -2,12 +2,17 @@
 import { useChannelStore } from '../../stores/channel';
 import PlayerInfo from '../player-info/player-info.vue';
 import RockPaperScissors from '../rock-paper-scissors/rock-paper-scissors.vue';
+import LoadingAnimation from '../loading-animation/loading-animation.vue';
 
 const channelStore = useChannelStore();
 </script>
 
 <template>
-  <div class="game-screen">
+  <div class="channel-closing" v-if="channelStore.channel?.channelIsClosing">
+    <div>Channel is closing...</div>
+    <LoadingAnimation />
+  </div>
+  <div class="game-screen" v-else>
     <div class="user">
       <PlayerInfo name="You" :balance="channelStore.channel?.balances.user" />
       <RockPaperScissors :isPlayerUser="true" />
@@ -22,6 +27,15 @@ const channelStore = useChannelStore();
 <style scoped lang="scss">
 @import '../../mediaqueries.scss';
 
+.channel-closing {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  font-size: 40px;
+  font-weight: 500;
+}
 .game-screen {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/client/src/components/header/header.vue
+++ b/client/src/components/header/header.vue
@@ -4,9 +4,20 @@ import { default as Button } from '../generic-button/generic-button.vue';
 import GameInfo from '../game-info/game-info.vue';
 import { resetApp } from '../../main';
 import { computed } from 'vue';
+import {
+  IS_USING_LOCAL_NODE,
+  NODE_URL,
+} from '../../utils/sdk-service/sdk-service';
 
 const channelStore = useChannelStore();
-const repoURL = 'https://github.com/aeternity/state-channel-demo';
+const repoUrl = 'https://github.com/aeternity/state-channel-demo';
+
+const explorerUrl = computed(() => {
+  if (IS_USING_LOCAL_NODE) {
+    return `${NODE_URL}/v2/channels/${channelStore.channel?.channelId}`;
+  } else
+    return `https://testnet.aenalytics.org/accounts/${channelStore.channel?.channelConfig?.responderId}`;
+});
 
 const canCloseChannel = computed(() => {
   return (
@@ -60,8 +71,12 @@ async function reset() {
       "
       class="links"
     >
-      <Button :url="repoURL" text="Fork repo" />
-      <Button text="Check Explorer" disabled />
+      <Button :url="repoUrl" text="Fork repo" />
+      <Button
+        :url="explorerUrl"
+        text="Check Explorer"
+        :disabled="explorerUrl"
+      />
       <Button
         text="End Game"
         :disabled="!canCloseChannel"
@@ -89,6 +104,9 @@ async function reset() {
   }
   @include for-phone-only {
     height: 15%;
+  }
+  @include for-big-desktop-up {
+    align-items: flex-start;
   }
 
   &.end-screen {

--- a/client/src/components/transaction/transaction.test.ts
+++ b/client/src/components/transaction/transaction.test.ts
@@ -4,14 +4,14 @@ import { SignatureType } from '../../utils/game-channel/game-channel.types';
 import SingleTransaction, { TransactionLog } from './transaction.vue';
 
 const mockTransactionLog: TransactionLog = {
-  id: 'tx_123',
+  id: 'th_123',
   description: 'Test Tx',
   signed: SignatureType.proposed,
   onChain: false,
   timestamp: Date.now(),
 };
 const mockOnChainTransactionLog: TransactionLog = {
-  id: 'tx_123',
+  id: 'th_123',
   description: 'Test Tx',
   signed: SignatureType.declined,
   onChain: true,

--- a/client/src/components/transaction/transaction.vue
+++ b/client/src/components/transaction/transaction.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 import { SignatureType } from '../../utils/game-channel/game-channel.types';
 
 export interface TransactionLog {
-  id: string;
+  id: Encoded.TxHash;
   onChain: boolean;
   description: string;
   signed: SignatureType;
   timestamp: number;
 }
+
 defineProps<{
   transaction?: TransactionLog;
 }>();

--- a/client/src/stores/transactions.ts
+++ b/client/src/stores/transactions.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { TransactionLog } from '../components/transaction/transaction.vue';
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 
 interface TransactionsStore {
   userTransactions: Array<Array<TransactionLog>>;
@@ -26,6 +27,17 @@ export const useTransactionsStore = defineStore('transactions', {
     },
     setBotTransactions(transactions: TransactionLog[][]) {
       this.botTransactions = transactions;
+    },
+    updateOpenChannelTransactions(newId: Encoded.TxHash) {
+      const userTxIdx = this.userTransactions[0].findIndex(
+        (transaction) => transaction.description === 'Open state channel'
+      );
+      if (userTxIdx !== -1) this.userTransactions[0][userTxIdx].id = newId;
+
+      const botTxIdx = this.botTransactions[0].findIndex(
+        (transaction) => transaction.description === 'Open state channel'
+      );
+      if (botTxIdx !== -1) this.botTransactions[0][botTxIdx].id = newId;
     },
   },
 });

--- a/client/src/utils/sdk-service/sdk-service.ts
+++ b/client/src/utils/sdk-service/sdk-service.ts
@@ -18,6 +18,7 @@ const FAUCET_PUBLIC_ADDRESS = import.meta.env
   .VITE_FAUCET_PUBLIC_ADDRESS as Encoded.AccountAddress;
 
 export let sdk: AeSdk;
+export let node: Node;
 export const keypair = generateKeyPair();
 
 export async function refreshSdkAccount() {
@@ -28,7 +29,7 @@ export async function refreshSdkAccount() {
 
 export async function getNewSdk() {
   const account = new MemoryAccount({ keypair });
-  const node = new Node(NODE_URL);
+  node = new Node(NODE_URL);
   const newSdk = new AeSdk({
     nodes: [{ name: 'testnet', instance: node }],
     compilerUrl: COMPILER_URL,

--- a/client/tests/mocks.ts
+++ b/client/tests/mocks.ts
@@ -1,23 +1,24 @@
 import { SignatureType } from '../src/utils/game-channel/game-channel.types';
+import { TransactionLog } from '../src/components/transaction/transaction.vue';
 
-export const mockUserTransactions = [
+export const mockUserTransactions: TransactionLog[][] = [
   [
     {
-      id: '1',
+      id: 'th_1',
       description: 'User Initial Transaction',
       signed: SignatureType.proposed,
       onChain: true,
       timestamp: Date.now(),
     },
     {
-      id: '2',
+      id: 'th_2',
       description: 'User Deploy Contract Transaction',
       signed: SignatureType.proposed,
       onChain: true,
       timestamp: Date.now(),
     },
     {
-      id: '4',
+      id: 'th_4',
       description: 'User Shutdown Transaction',
       signed: SignatureType.proposed,
       onChain: true,
@@ -26,7 +27,7 @@ export const mockUserTransactions = [
   ],
   [
     {
-      id: '3',
+      id: 'th_3',
       description: 'User Round 1 Transaction',
       signed: SignatureType.proposed,
       onChain: false,
@@ -35,24 +36,24 @@ export const mockUserTransactions = [
   ],
 ];
 
-export const mockBotTransactions = [
+export const mockBotTransactions: TransactionLog[][] = [
   [
     {
-      id: '1',
+      id: 'th_1',
       description: 'Bot Initial Transaction',
       signed: SignatureType.proposed,
       onChain: true,
       timestamp: Date.now(),
     },
     {
-      id: '2',
+      id: 'th_2',
       description: 'Bot Deploy Contract Transaction',
       signed: SignatureType.proposed,
       onChain: false,
       timestamp: Date.now(),
     },
     {
-      id: '4',
+      id: 'th_4',
       description: 'Bot Shutdown Transaction',
       signed: SignatureType.proposed,
       onChain: true,
@@ -61,7 +62,7 @@ export const mockBotTransactions = [
   ],
   [
     {
-      id: '3',
+      id: 'th_3',
       description: 'Bot Round 1 Transaction',
       signed: SignatureType.proposed,
       onChain: false,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,7 +4,7 @@ import { route } from './route';
 
 export const app = express();
 
-const corsOptions = process.env.NODE_ENV === 'development'
+const corsOptions = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'testnet'
   ? null
   : {
     origin: [/\.aeternity\.com\/?$/, /\.aepps\.com\/?$/],

--- a/server/src/services/bot/bot.interface.ts
+++ b/server/src/services/bot/bot.interface.ts
@@ -31,7 +31,7 @@ export enum SignatureType {
   declined = 'Declined',
 }
 export interface TransactionLog {
-  id: string;
+  id: Encoded.TxHash;
   onChain: boolean;
   description: string;
   signed: SignatureType;

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -1,4 +1,5 @@
 import {
+  buildTxHash,
   Channel,
   generateKeyPair,
   MemoryAccount,
@@ -97,7 +98,7 @@ export async function sendCallUpdateLog(
     gameSession.contractState.instance.bytecode,
   );
   const txLog: TransactionLog = {
-    id: tx,
+    id: buildTxHash(tx),
     description: `${data.function}()`,
     signed: SignatureType.confirmed,
     onChain: false,
@@ -381,7 +382,7 @@ export async function generateGameSession(
         // we are signing the channel open transaction
         openStateChannelTxLog = {
           description: 'Open state channel',
-          id: tx,
+          id: buildTxHash(tx),
           onChain: true,
           signed: SignatureType.proposed,
           timestamp: Date.now(),
@@ -395,7 +396,7 @@ export async function generateGameSession(
             type: 'add_bot_transaction_log',
             data: {
               description: 'Close state channel',
-              id: tx,
+              id: buildTxHash(tx),
               onChain: true,
               signed: SignatureType.confirmed,
               timestamp: Date.now(),

--- a/server/src/services/contract/contract.service.ts
+++ b/server/src/services/contract/contract.service.ts
@@ -1,4 +1,4 @@
-import { Channel } from '@aeternity/aepp-sdk';
+import { buildTxHash, Channel } from '@aeternity/aepp-sdk';
 import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
 import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 import contractSource from '@aeternity/rock-paper-scissors';
@@ -61,7 +61,7 @@ export async function deployContract(
     },
     async (tx) => {
       const log: TransactionLog = {
-        id: tx,
+        id: buildTxHash(tx),
         onChain: false,
         description: 'Deploy contract',
         timestamp: Date.now(),


### PR DESCRIPTION
- show tx-hash instead of tx-id in transaction logs
- show loader when closing channel
- add check-explorer button that takes user to the aenalytics page of the users address