### PR TITLE
fix: clear local storage on channel close

### DIFF
--- a/client/src/utils/game-channel/game-channel.ts
+++ b/client/src/utils/game-channel/game-channel.ts
@@ -264,6 +264,7 @@ export class GameChannel {
     await channelClosing.then(async (canClose) => {
       if (!canClose) return;
       this.channelIsClosing = true;
+      localStorage.clear();
       await this.getChannelWithoutProxy()
         .shutdown((tx: Encoded.Transaction) => this.signTx('channel_close', tx))
         .then(async () => {


### PR DESCRIPTION
This PR fixes an issue where local storage wasn't being cleared on channel-close and was causing unwanted behavior on page-refresh.