### PR TITLE
refactor: use a 2 minute timeout idle

### DIFF
--- a/server/src/services/bot/bot.constants.ts
+++ b/server/src/services/bot/bot.constants.ts
@@ -22,8 +22,8 @@ export const MUTUAL_CHANNEL_CONFIGURATION: Partial<ChannelOptions> & {
   // execute channel_settle transaction
   // read more: https://github.com/aeternity/protocol/blob/master/channels/ON-CHAIN.md#channel_settle
   lockPeriod: 0,
-  // workaround: minimize the number of node hangs
-  timeoutIdle: 2 * 60 * 60 * 1000,
+  // peers need to respond in maximum 2 minutes
+  timeoutIdle: 2 * 60 * 1000,
   debug: false,
   // How to calculate minimum depth - either txfee (default) or plain. We use
   // `plain` with `minimumDepth` in order to reduce delay.


### PR DESCRIPTION
In order to close channels sooner, we setup a 2minute window availability