### PR TITLE
feat: add debug status endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   node:
-    image: aeternity/aeternity:${NODE_TAG-v6.5.2}
+    image: aeternity/aeternity:${NODE_TAG-v6.6.0}
     hostname: node
     ports: ["3013:3013", "3113:3113", "3014:3014", "3114:3114"]
     volumes:

--- a/server/src/route/route.spec.ts
+++ b/server/src/route/route.spec.ts
@@ -1,19 +1,118 @@
+import { Channel } from '@aeternity/aepp-sdk';
 import { ChannelOptions } from '@aeternity/aepp-sdk/es/channel/internal';
+import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
+import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 import supertest from 'supertest';
-import { app } from '../app';
 import { mockChannel } from '../../test';
+import { app } from '../app';
+import env from '../env';
 import { MUTUAL_CHANNEL_CONFIGURATION } from '../services/bot';
+import { addGameSession, removeGameSession } from '../services/bot/bot.service';
+import { ContractService } from '../services/contract';
+
+const config: {
+  address: Encoded.AccountAddress;
+  port: number;
+  host: string;
+} = {
+  address: 'ak_2fnsAzkXfvWKZJXx2bkPSWMtpBpfEXFhJpL9ThFLWMxQ7G9wag',
+  port: 8000,
+  host: 'localhost',
+};
+
+const deployContractSpy = jest.spyOn(ContractService, 'deployContract');
+
+describe('/status', () => {
+  async function fetchStatus() {
+    return supertest(app).get('/status').set('Accept', 'application/json');
+  }
+
+  it('returns 0 as default values', async () => {
+    const res = await fetchStatus();
+    const currentDate = new Date();
+
+    expect(res.status).toBe(200);
+    expect(
+      currentDate.getMilliseconds()
+        - new Date(res.body.runningSince as number).getMilliseconds(),
+    ).toBeLessThan(1000);
+    expect(res.body).toEqual({
+      channelsOpenCurrently: 0,
+      channelsInitialized: 0,
+      channelsOpened: 0,
+      runningSince: expect.any(String),
+      env: {
+        ...env.development,
+      },
+    });
+  });
+
+  it('increments channels', async () => {
+    await supertest(app)
+      .post('/open')
+      .send(config)
+      .set('Accept', 'application/json');
+
+    const initialRes = await fetchStatus();
+
+    expect(initialRes.body.channelsInitialized).toBe(1);
+    expect(initialRes.body.channelsOpened).toBe(0);
+    expect(initialRes.body.channelsOpenCurrently).toBe(0);
+
+    deployContractSpy.mockResolvedValue({
+      instance: {} as ContractInstance,
+      address: 'ct_2fnsAzkXfvWKZJXx2bkPSWMtpBpfEXFhJpL9ThFLWMxQ7G9wag',
+    });
+    await addGameSession(
+      {
+        balances: jest.fn,
+        state: jest.fn,
+        poi: jest.fn,
+      } as unknown as Channel,
+      {
+        initiatorId: config.address,
+        responderId: 'ak_2fnsAzkXfvWKZJXx2bkPSWMtpBpfEXFhJpL9ThFLWMxQ7G9waz',
+      } as unknown as ChannelOptions,
+    );
+
+    const res = await fetchStatus();
+
+    const currentDate = new Date();
+
+    expect(res.status).toBe(200);
+    expect(
+      currentDate.getMilliseconds()
+        - new Date(res.body.runningSince as number).getMilliseconds(),
+    ).toBeLessThan(1000);
+    expect(res.body).toEqual({
+      channelsOpenCurrently: 1,
+      channelsInitialized: 1,
+      channelsOpened: 1,
+      runningSince: expect.any(String),
+      env: {
+        ...env.development,
+      },
+    });
+  });
+
+  it('decrements channels', async () => {
+    removeGameSession(config.address);
+
+    const res = await supertest(app)
+      .get('/status')
+      .set('Accept', 'application/json');
+
+    expect(res.body.channelsOpenCurrently).toBe(0);
+    expect(res.body.channelsOpened).toBe(1);
+    expect(res.body.channelsInitialized).toBe(1);
+  });
+});
 
 describe('/open', () => {
   jest.setTimeout(15000);
   mockChannel();
 
   it('retrieves channel configuration', async () => {
-    const config = {
-      address: 'ak_2fnsAzkXfvWKZJXx2bkPSWMtpBpfEXFhJpL9ThFLWMxQ7G9wag',
-      port: 8000,
-      host: 'localhost',
-    };
     const res = await supertest(app)
       .post('/open')
       .send(config)

--- a/server/src/route/route.ts
+++ b/server/src/route/route.ts
@@ -11,6 +11,10 @@ route.get('/', (_req, res) => {
   );
 });
 
+route.get('/status', (_req, res) => {
+  res.json(botService.getServiceStatus());
+});
+
 route.post('/open', (async (req, res) => {
   const reqBody = req.body as Partial<ResponderBaseChannelConfig>;
   const { address, port, host } = reqBody;

--- a/server/src/services/bot/bot.interface.ts
+++ b/server/src/services/bot/bot.interface.ts
@@ -4,6 +4,7 @@ import { ChannelState } from '@aeternity/aepp-sdk/es/channel/internal';
 import { ContractInstance } from '@aeternity/aepp-sdk/es/contract/aci';
 import { Encoded } from '@aeternity/aepp-sdk/es/utils/encoder';
 import { Moves } from '../contract/contract.constants';
+import { ENVIRONMENT_CONFIG } from '../sdk';
 
 export interface GameSession {
   channelWrapper: {
@@ -26,6 +27,14 @@ export interface GameSession {
     responderId: Encoded.AccountAddress;
     initiatorId: Encoded.AccountAddress;
   };
+}
+
+export interface ServiceStatus {
+  channelsOpenCurrently: number;
+  channelsInitialized: number;
+  channelsOpened: number;
+  runningSince: Date;
+  env: typeof ENVIRONMENT_CONFIG;
 }
 
 export enum SignatureType {

--- a/server/src/services/sdk/sdk.constants.ts
+++ b/server/src/services/sdk/sdk.constants.ts
@@ -9,15 +9,17 @@ if (!Object.keys(env).includes(ENVIRONMENT)) {
   throw new Error(`Environment ${ENVIRONMENT} is not defined in env/index.ts`);
 }
 
-export const WEBSOCKET_URL = env[ENVIRONMENT]?.WS_URL;
-export const NODE_URL = env[ENVIRONMENT]?.NODE_URL;
-export const COMPILER_URL = env[ENVIRONMENT]?.COMPILER_URL;
-export const NETWORK_ID = env[ENVIRONMENT]?.NETWORK_ID;
-export const IGNORE_NODE_VERSION = env[ENVIRONMENT]?.IGNORE_VERSION === 'true';
-export const FAUCET_PUBLIC_ADDRESS = env[ENVIRONMENT]?.FAUCET_PUBLIC_ADDRESS;
+export const ENVIRONMENT_CONFIG = env[ENVIRONMENT];
+
+export const WEBSOCKET_URL = ENVIRONMENT_CONFIG.WS_URL;
+export const {
+  NODE_URL, COMPILER_URL, NETWORK_ID, FAUCET_PUBLIC_ADDRESS,
+} = ENVIRONMENT_CONFIG;
+export const IGNORE_NODE_VERSION = ENVIRONMENT_CONFIG.IGNORE_VERSION === 'true';
 export const IS_USING_LOCAL_NODE = !NODE_URL?.includes('testnet');
-// ! LOCAL NODE USAGE ONLY
-const FAUCET_SECRET_KEY = ENVIRONMENT === 'development' && env[ENVIRONMENT]?.FAUCET_SECRET_KEY;
+// ! LOCAL NODE & DEVELOPMENT NETWORK USAGE ONLY
+const FAUCET_SECRET_KEY = ENVIRONMENT === 'development'
+  && (ENVIRONMENT_CONFIG as typeof env['development'])?.FAUCET_SECRET_KEY;
 export const FAUCET_ACCOUNT = IS_USING_LOCAL_NODE
   ? new MemoryAccount({
     keypair: {


### PR DESCRIPTION
This PR adds `/status` endpoint which aims to provides us with context regarding the currently running deploy

closes #133 