### PR TITLE
fix: handle tx log unable to be sent

### DIFF
--- a/client/src/utils/game-channel/game-channel.ts
+++ b/client/src/utils/game-channel/game-channel.ts
@@ -258,6 +258,7 @@ export class GameChannel {
           );
           this.shouldShowEndScreen = true;
           this.isOpen = false;
+          channel.disconnect();
         });
     });
     return channelClosing;

--- a/server/src/route/route.spec.ts
+++ b/server/src/route/route.spec.ts
@@ -68,6 +68,7 @@ describe('/status', () => {
         balances: jest.fn,
         state: jest.fn,
         poi: jest.fn,
+        disconnect: jest.fn,
       } as unknown as Channel,
       {
         initiatorId: config.address,

--- a/server/test/interfaces.ts
+++ b/server/test/interfaces.ts
@@ -3,4 +3,5 @@ export interface ChannelMock {
     [eventName: string]: (...args: any[]) => void;
   };
   on: (eventName: string, listener: (...args: any[]) => void) => void;
+  disconnect: () => void;
 }

--- a/server/test/mocks.ts
+++ b/server/test/mocks.ts
@@ -26,6 +26,7 @@ export const mockChannel = () => {
         return {};
       },
       createContract: jest.fn(),
+      disconnect: jest.fn(),
     } as ChannelMock),
   );
 };


### PR DESCRIPTION
This PR handles some rare cases where the tx hash cannot be built. (occurred during load testing). 

Also explicitly disconnects channels on closure