### PR TITLE
feat(client): automatically start new round after 1 second

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -18,7 +18,7 @@
     <div id="app" class="container">
       <!-- #region Header -->
       <div class="header">
-        <button id="reset">
+        <button id="reset" style="background-color: transparent; border: none">
           <img
             src="./src/assets/images/logo.png"
             :class="{ clickable: canCloseChannel || canResetApp }"
@@ -29,14 +29,14 @@
           <!-- if channel is open -->
           <div class="round-info">
             <span class="title">Game</span>
-            <div class="info" v-if="stake">
+            <div class="info" style="opacity: 0">
               <span class="stake">
-                <!-- {{ stake.dividedBy(1e18).toFormat(2) }} -->
-                STAKE: -1 Æ
+                STAKE: <span class="stake-value"></span> Æ
               </span>
-              <span class="info-seperator" v-if="round"> / </span>
-              <!-- ROUND: {{ round }} -->
-              <span v-if="round">ROUND: -1</span>
+              <span class="info-seperator"> / </span>
+              <span class="round-wrapper"
+                >ROUND: <span class="round-index"></span
+              ></span>
             </div>
           </div>
         </div>
@@ -70,7 +70,7 @@
               </div>
               <h1 class="status title"></h1>
               <div class="finalized-selection">
-                <div class="selection-icon" :class="{ victory, defeat }">
+                <div class="selection-icon" style="display: none">
                   <!-- Here we should show the final selection of the user -->
                   <!-- ./src/assets/images/${props.type}.png -->
                   <img src="./src/assets/images/paper.png" />
@@ -113,7 +113,7 @@
           <div class="rock-paper-scissors">
             <div class="rock-paper-scissors__header">
               <div class="finalized-selection">
-                <div class="selection-icon" :class="{ victory, defeat }">
+                <div class="selection-icon" style="display: none">
                   <!-- Here we should show the final selection of the bot -->
                   <!-- ./src/assets/images/${props.type}.png -->
                   <img src="./src/assets/images/paper.png" />

--- a/client/main.js
+++ b/client/main.js
@@ -1,24 +1,7 @@
-import { setMoveSelectionDisability } from './src/js/dom-manipulation/dom-manipulation';
-import { gameChannel } from './src/js/game-channel/game-channel';
-import { Selections } from './src/js/game-channel/game-channel.enums';
-import { initSdk } from './src/js/sdk-service/sdk-service';
 import './src/js/autoplay/autoplay-btn.controler';
+import { initSdk } from './src/js/sdk-service/sdk-service';
+import { handleAppMount } from './src/js/dom-manipulation/dom-manipulation';
+import { gameChannel } from './src/js/game-channel/game-channel';
 
 initSdk();
-
-document.querySelectorAll('.selections button').forEach((button, index) => {
-  button.addEventListener('click', async () => {
-    if (!gameChannel.isOpen && !gameChannel.isOpening) {
-      setMoveSelectionDisability(true);
-      await gameChannel.initializeChannel();
-    }
-    const selection = Object.values(Selections)[index];
-    console.log(selection);
-    if (gameChannel.contractAddress)
-      await gameChannel.setUserSelection(selection);
-    else
-      await gameChannel.pollForContract(() =>
-        gameChannel.setUserSelection(selection)
-      );
-  });
-});
+handleAppMount(gameChannel);

--- a/client/main.js
+++ b/client/main.js
@@ -3,5 +3,7 @@ import { initSdk } from './src/js/sdk-service/sdk-service';
 import { handleAppMount } from './src/js/dom-manipulation/dom-manipulation';
 import { gameChannel } from './src/js/game-channel/game-channel';
 
-initSdk();
-handleAppMount(gameChannel);
+initSdk().then(async () => {
+  await gameChannel.restoreGameState();
+  handleAppMount(gameChannel);
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,6 +25,7 @@
       }
     },
     "../contract": {
+      "name": "@aeternity/rock-paper-scissors",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/client/src/js/dom-manipulation/dom-manipulation.js
+++ b/client/src/js/dom-manipulation/dom-manipulation.js
@@ -1,10 +1,25 @@
+import { Selections } from '../game-channel/game-channel.enums';
+
 /**
  * @typedef {import("bignumber.js").BigNumber} BigNumber
  * @typedef {'user' | 'bot'} Participant
  * @typedef {import("../game-channel/game-channel.enums").Selections} Selections
+ * @typedef {import("../game-channel/game-channel").GameChannel} GameChannel
  */
 
 import { resetApp } from '../local-storage/local-storage';
+
+/**
+ * @param {Participant} participant
+ */
+function _getParticipantSelectionIcon(participant) {
+  if (participant !== 'user' && participant !== 'bot')
+    throw new Error('Invalid participant');
+
+  return document.querySelector(
+    `.${participant} .finalized-selection .selection-icon`
+  );
+}
 
 /**
  * @param {string} id
@@ -74,13 +89,32 @@ export function hideElement(selector) {
   element.style.display = 'none';
 }
 
+export function showGameInfo() {
+  document.querySelector('.info').style.opacity = '1';
+}
+
 /**
  * @param {boolean} disability
  */
 export function setMoveSelectionDisability(isDisabled) {
   document.querySelector('.selections').style.display = isDisabled
     ? 'none'
-    : 'initial';
+    : 'flex';
+}
+/**
+ * @param {BigNumber} amount
+ */
+export function setStakeAmount(amount) {
+  document.querySelector('.stake-value').textContent = amount
+    .dividedBy(1e18)
+    .toFormat(2);
+}
+
+/**
+ * @param {number} round
+ */
+export function setGameRoundIndex(index) {
+  document.querySelector('.round-index').textContent = index;
 }
 
 /**
@@ -103,10 +137,35 @@ export function setFinalizedSelection(participant, selection) {
   if (participant != 'user' && participant != 'bot') {
     throw new Error('invalid participant selector');
   }
-  const wrapper = document.querySelector(
-    `.${participant} .finalized-selection .selection-icon`
-  );
+  const wrapper = _getParticipantSelectionIcon(participant);
+
+  wrapper.style.display = 'flex';
   wrapper.querySelector('img').src = `./src/assets/images/${selection}.png`;
+}
+
+export function resetSelections() {
+  const userSelection = _getParticipantSelectionIcon('user');
+  const botSelection = _getParticipantSelectionIcon('bot');
+  userSelection.classList.remove('victory', 'defeat', 'draw');
+  botSelection.classList.remove('victory', 'defeat', 'draw');
+  userSelection.style.display = 'none';
+  botSelection.style.display = 'none';
+  setMoveSelectionDisability(false);
+}
+
+/**
+ * @param {'user' | 'bot' | 'none'} result
+ */
+export function colorizeSelections(winner) {
+  const userSelection = _getParticipantSelectionIcon('user');
+  const botSelection = _getParticipantSelectionIcon('bot');
+  if (winner == 'user') {
+    userSelection.classList.add('victory');
+    botSelection.classList.add('defeat');
+  } else if (winner == 'bot') {
+    userSelection.classList.add('defeat');
+    botSelection.classList.add('victory');
+  }
 }
 
 /**
@@ -135,6 +194,25 @@ export function setEndGameDisability(isDisabled) {
   document.querySelector('#end-game').disabled = isDisabled;
 }
 
-export function handleAppMount() {
+/**
+ *
+ * @param {GameChannel} gameChannel
+ */
+export function handleAppMount(gameChannel) {
   document.getElementById('reset').addEventListener('click', resetApp);
+  document.querySelectorAll('.selections button').forEach((button, index) => {
+    button.addEventListener('click', async () => {
+      if (!gameChannel.isOpen && !gameChannel.isOpening) {
+        setMoveSelectionDisability(true);
+        await gameChannel.initializeChannel();
+      }
+      const selection = Object.values(Selections)[index];
+      if (gameChannel.contractAddress)
+        await gameChannel.setUserSelection(selection);
+      else
+        await gameChannel.pollForContract(() =>
+          gameChannel.setUserSelection(selection)
+        );
+    });
+  });
 }

--- a/client/src/js/dom-manipulation/dom-manipulation.js
+++ b/client/src/js/dom-manipulation/dom-manipulation.js
@@ -154,9 +154,12 @@ export function resetSelections() {
 }
 
 /**
- * @param {'user' | 'bot' | 'none'} result
+ * @param {'user' | 'bot' | 'none'} winner
  */
 export function colorizeSelections(winner) {
+  if (winner !== 'user' && winner !== 'bot' && winner !== 'none') {
+    throw new Error('invalid winner selector');
+  }
   const userSelection = _getParticipantSelectionIcon('user');
   const botSelection = _getParticipantSelectionIcon('bot');
   if (winner == 'user') {

--- a/client/src/js/game-channel/game-channel.js
+++ b/client/src/js/game-channel/game-channel.js
@@ -38,7 +38,6 @@ import {
   updateOpenChannelTransactions,
 } from '../terminal/terminal';
 import { DomMiddleware } from './game-channel.middleware';
-
 /**
  * @typedef {import("../../types").GameRound} GameRound
  * @typedef {import("../../types").Update} Update
@@ -80,6 +79,7 @@ export class GameChannel {
   channelIsClosing = false;
   savedResultsOnChainTxHash = null;
   hasInsuffientBalance = false;
+  shouldHandleReconnection = false;
   error = null;
   balances = {
     user: undefined,
@@ -791,6 +791,7 @@ export class GameChannel {
       savedState.contractCreationChannelRound,
       savedState.channelConfig?.initiatorId
     );
+    this.shouldHandleReconnection = true;
     await this.updateBalances();
 
     if (savedState.gameRound.userSelection === Selections.none) return;
@@ -831,7 +832,12 @@ export class GameChannel {
  */
 for (const key of Object.getOwnPropertyNames(GameChannel.prototype)) {
   const method = GameChannel.prototype[key];
-  const excludedMethods = ['pollForContract'];
+  const excludedMethods = [
+    'pollForContract',
+    'restoreGameState',
+    'reconnectChannel',
+    'registerEvents',
+  ];
   if (excludedMethods.includes(key)) continue;
   if (method.constructor.name === 'AsyncFunction') {
     GameChannel.prototype[key] = async function (...args) {

--- a/client/src/js/game-channel/game-channel.middleware.js
+++ b/client/src/js/game-channel/game-channel.middleware.js
@@ -1,21 +1,63 @@
 import * as DOMUpdate from '../dom-manipulation/dom-manipulation';
 
+let resetPromise = null;
+
+/**
+ * @param {import("../game-channel/game-channel").GameChannel} gameChannel
+ */
 export function DomMiddleware(gameChannel) {
   if (gameChannel.isOpen) {
     DOMUpdate.setParticipantBalance('user', gameChannel.balances.user);
     DOMUpdate.setParticipantBalance('bot', gameChannel.balances.bot);
+    DOMUpdate.setGameRoundIndex(gameChannel.gameRound.index);
+    DOMUpdate.setStakeAmount(gameChannel.gameRound.stake);
+    DOMUpdate.showGameInfo(false);
+
+    const canReset = gameChannel.isOpen && gameChannel.shouldShowEndScreen;
+    const canClose =
+      gameChannel.isOpen &&
+      !gameChannel.gameRound.userInAction &&
+      gameChannel.channelIsClosing;
+
+    if (canReset || canClose) {
+      DOMUpdate.setResetDisability(false);
+    } else DOMUpdate.setResetDisability(true);
+    if (canClose) {
+      DOMUpdate.setEndGameDisability(false);
+    } else DOMUpdate.setEndGameDisability(true);
+
+    if (gameChannel.gameRound.userSelection != 'none') {
+      DOMUpdate.setMoveStatus('user', 'Waiting for bot...');
+      DOMUpdate.setMoveStatus('bot', '');
+      DOMUpdate.setFinalizedSelection(
+        'user',
+        gameChannel.gameRound.userSelection
+      );
+      DOMUpdate.setMoveSelectionDisability(true);
+    }
+
+    if (gameChannel.gameRound.isCompleted) {
+      DOMUpdate.setMoveStatus('user', '');
+      DOMUpdate.setFinalizedSelection(
+        'bot',
+        gameChannel.gameRound.botSelection
+      );
+      let winner;
+      switch (gameChannel.gameRound.winner) {
+        case gameChannel.channelConfig.initiatorId:
+          winner = 'bot';
+          break;
+        case gameChannel.channelConfig.responderId:
+          winner = 'user';
+          break;
+      }
+      DOMUpdate.colorizeSelections(winner);
+    } else if (gameChannel.gameRound.botSelection == 'none' && !resetPromise) {
+      resetPromise = setTimeout(() => {
+        DOMUpdate.setMoveStatus('bot', 'Waiting for user...');
+        DOMUpdate.resetSelections();
+        resetPromise = null;
+      }, 1000);
+    }
   }
-
-  const canReset = gameChannel.isOpen && gameChannel.shouldShowEndScreen;
-  const canClose =
-    gameChannel.isOpen &&
-    !gameChannel.gameRound.userInAction &&
-    gameChannel.channelIsClosing;
-
-  if (canReset || canClose) {
-    DOMUpdate.setResetDisability(false);
-  } else DOMUpdate.setResetDisability(true);
-  if (canClose) {
-    DOMUpdate.setEndGameDisability(false);
-  } else DOMUpdate.setEndGameDisability(true);
 }


### PR DESCRIPTION
This PR moves more business logic from the vuejs version apart from 
- terminal log updates
- end game

It also removes start new round buttons and automatically starts the next round after 1 second. This feature was not intended for this pr yet it was mandatory due to the current nature of logic