### PR TITLE
feat: show share buttons asynchronously

### DIFF
--- a/client/src/components/end-screen/end-screen.vue
+++ b/client/src/components/end-screen/end-screen.vue
@@ -64,11 +64,12 @@ const earnings = computed(() => {
   return balance.minus(initialBalance);
 });
 
-function getLinkToShare() {
-  return `${window.location.origin.concat(window.location.pathname)}?th=${
-    channel?.savedResultsOnChainTxHash
-  }`;
-}
+const getLinkToShare = computed(
+  () =>
+    `${window.location.origin.concat(window.location.pathname)}?th=${
+      channel?.savedResultsOnChainTxHash
+    }`
+);
 
 function closeChannel() {
   channel?.closeChannel();
@@ -109,9 +110,23 @@ function continueAutoplay() {
         @click="closeChannel()"
       />
       <div class="share-results" v-if="!props.resultsFromSharedLink">
-        <ShareButtons v-if="!channel.isOpen" :url="getLinkToShare()" />
-        <div v-else-if="channel.channelIsClosing" class="text">
+        <ShareButtons
+          v-if="!channel.isOpen && channel.savedResultsOnChainTxHash"
+          :url="getLinkToShare"
+        />
+        <div
+          v-else-if="channel.channelIsClosing && channel.isOpen"
+          class="text"
+        >
           Channel is closing...
+        </div>
+        <div
+          v-else-if="
+            !channel.savedResultsOnChainTxHash && channel.channelIsClosing
+          "
+          class="text"
+        >
+          Saving results...
         </div>
       </div>
       <Button

--- a/client/src/utils/game-channel/game-channel.ts
+++ b/client/src/utils/game-channel/game-channel.ts
@@ -253,12 +253,13 @@ export class GameChannel {
       await channel
         .shutdown((tx: Encoded.Transaction) => this.signTx('channel_close', tx))
         .then(async () => {
-          this.savedResultsOnChainTxHash = await returnCoinsToFaucet(
-            this.getMessageToSaveOnChain()
-          );
           this.shouldShowEndScreen = true;
           this.isOpen = false;
           channel.disconnect();
+
+          returnCoinsToFaucet(this.getMessageToSaveOnChain()).then(
+            async (txHash) => (this.savedResultsOnChainTxHash = txHash)
+          );
         });
     });
     return channelClosing;


### PR DESCRIPTION
In order to reduce the time the user has to wait to see the end-screen we now show share-buttons in an asynchronous matter.