### PR TITLE
refactor: clear local storage after channel has closed

### DIFF
--- a/client/src/js/game-channel/game-channel.js
+++ b/client/src/js/game-channel/game-channel.js
@@ -247,7 +247,6 @@ export class GameChannel {
   }
 
   async closeChannel() {
-    localStorage.clear();
     if (!channel) {
       throw new Error('Channel is not open');
     }
@@ -281,6 +280,7 @@ export class GameChannel {
           );
         });
     });
+    localStorage.clear();
     return channelClosing;
   }
 


### PR DESCRIPTION
Right now, due to the fact that local storage clearing is called initially, its content is filled right before actual channel closing which means that on window reload, localstorage will already be filled with the previous state. This PR clears localstorage as the last move instead of the first.