### PR TITLE
feat(server): add an authenticated endpoint to cleanup stats

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -4,6 +4,7 @@ process.env.NETWORK_ID = 'ae_devnet';
 process.env.COMPILER_URL = 'http://localhost:3080';
 process.env.NODE_URL = 'http://localhost:3013';
 process.env.WS_URL = 'ws://localhost:3014/channel';
+process.env.BOT_SERVICE_STAT_RESET_PASSWORD = 'strong-password';
 
 module.exports = {
   preset: 'ts-jest',

--- a/server/src/route/route.spec.ts
+++ b/server/src/route/route.spec.ts
@@ -41,6 +41,7 @@ describe('/status', () => {
       channelsInitialized: 0,
       channelsOpened: 0,
       runningSince: expect.any(Number),
+      lastReset: expect.any(Number),
       env: {
         ...env.development,
       },
@@ -92,6 +93,7 @@ describe('/status', () => {
       channelsInitialized: 1,
       channelsOpened: 1,
       runningSince: expect.any(Number),
+      lastReset: expect.any(Number),
       env: {
         ...env.development,
       },
@@ -108,6 +110,42 @@ describe('/status', () => {
     expect(res.body.channelsOpenCurrently).toBe(0);
     expect(res.body.channelsOpened).toBe(1);
     expect(res.body.channelsInitialized).toBe(1);
+  });
+
+  it('resets stats', async () => {
+    const initialStatus = await supertest(app)
+      .get('/status')
+      .set('Accept', 'application/json');
+
+    const res = await supertest(app)
+      .post('/status')
+      .set('Accept', 'application/json')
+      .set(
+        'Authorization',
+        `Authorization ${Buffer.from(
+          ` :${process.env.BOT_SERVICE_STAT_RESET_PASSWORD}`,
+        ).toString('base64')}`,
+      );
+
+    expect(res.body.lastReset).toBeGreaterThan(
+      initialStatus.body.lastReset as number,
+    );
+    expect(res.body.channelsOpenCurrently).toBe(0);
+    expect(res.body.channelsOpened).toBe(0);
+    expect(res.body.channelsInitialized).toBe(0);
+  });
+
+  it('fails to restart stats if not authenticated', async () => {
+    const res = await supertest(app)
+      .post('/status')
+      .set('Accept', 'application/json')
+      .set(
+        'Authorization',
+        `Authorization ${Buffer.from(' :test').toString('base64')}`,
+      );
+
+    expect(res.status).toBe(401);
+    expect(res.text).toBe('Access forbidden');
   });
 });
 

--- a/server/src/route/route.ts
+++ b/server/src/route/route.ts
@@ -15,6 +15,18 @@ route.get('/status', (_req, res) => {
   res.json(botService.getServiceStatus());
 });
 
+route.post('/status', (req, res) => {
+  const b64auth = (req.headers.authorization || '').split(' ')[1] || '';
+  const [, password] = Buffer.from(b64auth, 'base64').toString().split(':');
+  if (password === process.env.BOT_SERVICE_STAT_RESET_PASSWORD) {
+    botService.resetServiceStatus();
+    res.json(botService.getServiceStatus());
+  } else {
+    res.status(401);
+    res.send('Access forbidden');
+  }
+});
+
 route.post('/open', (async (req, res) => {
   const reqBody = req.body as Partial<ResponderBaseChannelConfig>;
   const { address, port, host } = reqBody;

--- a/server/src/services/bot/bot.interface.ts
+++ b/server/src/services/bot/bot.interface.ts
@@ -41,6 +41,7 @@ export interface ServiceStatus {
   channelsInitialized: number;
   channelsOpened: number;
   runningSince: number;
+  lastReset: number;
   env: typeof ENVIRONMENT_CONFIG;
 }
 

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -62,7 +62,7 @@ function timeout(ms: number) {
 }
 
 /**
- * Returns the current status of the game session service
+ * Resets the current status counters of the game session service
  */
 export function resetServiceStatus() {
   serviceStatus.channelsOpenCurrently = 0;

--- a/server/src/services/bot/bot.service.ts
+++ b/server/src/services/bot/bot.service.ts
@@ -42,11 +42,13 @@ import {
 
 export const gameSessionPool = new Map<string, GameSession>();
 
+const runningSince = Date.now();
 const serviceStatus: ServiceStatus = {
   channelsOpenCurrently: 0,
   channelsInitialized: 0,
   channelsOpened: 0,
-  runningSince: Date.now(),
+  runningSince,
+  lastReset: runningSince,
   env: ENVIRONMENT_CONFIG,
 };
 
@@ -57,6 +59,16 @@ function timeout(ms: number) {
   return new Promise((_, reject) => {
     setTimeout(() => reject(new Error('timeout succeeded')), ms);
   });
+}
+
+/**
+ * Returns the current status of the game session service
+ */
+export function resetServiceStatus() {
+  serviceStatus.channelsOpenCurrently = 0;
+  serviceStatus.channelsInitialized = 0;
+  serviceStatus.channelsOpened = 0;
+  serviceStatus.lastReset = Date.now();
 }
 
 /**


### PR DESCRIPTION
Creates an authenticated endpoint which resets the counter stats